### PR TITLE
chore(ci): verify chaos scripts

### DIFF
--- a/.ci/scripts/distribution/prepare.sh
+++ b/.ci/scripts/distribution/prepare.sh
@@ -1,4 +1,15 @@
 #!/bin/sh -eux
 
 apt-get -qq update
-apt-get install --no-install-recommends -qq -y jq libatomic1
+apt-get install --no-install-recommends -qq -y jq libatomic1 bats git
+
+# install shell check
+shellcheckVersion=v0.7.1
+wget "https://github.com/koalaman/shellcheck/releases/download/$shellcheckVersion/shellcheck-$shellcheckVersion.linux.x86_64.tar.xz"
+tar -xvf "shellcheck-$shellcheckVersion.linux.x86_64.tar.xz"
+cp "shellcheck-$shellcheckVersion"/shellcheck /usr/bin/shellcheck
+
+# install bats
+git clone https://github.com/bats-core/bats-core.git
+cd bats-core
+./install.sh /usr/local

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,20 @@ pipeline {
       }
     }
 
+    stage('Verify scripts') {
+      steps {
+          container('maven') {
+              dir('core/chaos-workers') {
+                  println("Check all chaos script`s with shellcheck (linter).")
+                  sh 'shellcheck -x *.sh'
+                  println("Scripts are fine.")
+                  println("Run bash tests via bats.")
+                  sh './*Test.sh'
+              }
+          }
+      }
+    }
+
     stage('Upload') {
       when {
       	not { expression { params.RELEASE } }

--- a/core/chaos-workers/.gitignore
+++ b/core/chaos-workers/.gitignore
@@ -1,1 +1,2 @@
 createAndRunImage.sh
+output-*.log

--- a/core/chaos-workers/installDependencies.sh
+++ b/core/chaos-workers/installDependencies.sh
@@ -9,7 +9,7 @@ pip install chaostoolkit
 chaos --version
 
 kubectl_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-curl -LO https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl"
 install kubectl /usr/local/bin/
 kubectl version --client
 


### PR DESCRIPTION
 Run shellcheck for all chaos bash scripts.
 Run bash unit tests in jenkins pipeline.
 Add a separate stage to verify the shell scripts

Dependencies are installed directly from repository, I tried some hours with debians package manager and the different backport channels etc but had no luck / didn't worked.

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/107