### PR TITLE
Some improvements to the chaos worker

### DIFF
--- a/core/chaos-workers/.gitignore
+++ b/core/chaos-workers/.gitignore
@@ -1,2 +1,3 @@
 createAndRunImage.sh
 output-*.log
+debugWorker.sh

--- a/core/chaos-workers/.gitignore
+++ b/core/chaos-workers/.gitignore
@@ -1,3 +1,4 @@
 createAndRunImage.sh
 output-*.log
 debugWorker.sh
+zeebe-chaos

--- a/core/chaos-workers/handleJob.sh
+++ b/core/chaos-workers/handleJob.sh
@@ -34,8 +34,8 @@ NAMESPACE=$(extractTargetNamespace "$variables")
 export NAMESPACE
 
 ################################################################################
-
-kubens "$NAMESPACE" &>> "$logFile" || (echo "{\"testResult\":\"FAILED\"}" && exit 1)
+kubens "$NAMESPACE" &>> "$logFile" \
+  || (createFailureMessage "Namespace '$NAMESPACE' doesn't exist" && exit 0)
 kubectl get pods &>> "$logFile"
 
 ################################################################################

--- a/core/chaos-workers/handleJob.sh
+++ b/core/chaos-workers/handleJob.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -oxu pipefail
 
-
 # import util methods
 # shellcheck source=handlerUtil.sh
 . handlerUtil.sh
@@ -15,7 +14,7 @@ touch "$logFile"
 # EXTRACT INPUT ################################################################
 ################################################################################
 
-variables=$(readStandardInput)
+variables=$(readStandardIn)
 
 clusterPlan=$(extractClusterPlan "$variables")
 

--- a/core/chaos-workers/handleJobTest.sh
+++ b/core/chaos-workers/handleJobTest.sh
@@ -82,25 +82,31 @@ failFunction() {
 }
 
 @test "run experiment with failing runner and values in array - return FAILED" {
+  # given
   array=(1 2)
+  expected="$(jq -n '{testResult: "FAILED", failureMessages: ["1 failed"], failureCount: 1, metaData: {}}')"
 
-  if runChaosExperiments failFunction "${array[@]}";
-  then
-    exit 1 # unexpected
-  fi
+  # when
+  result=$(runChaosExperiments failFunction "${array[@]}")
 
-  echo "expected"
+  # then
+  echo "actual: $result"
+  echo "expected: $expected"
+  [ "$result" == "$expected" ]
 }
 
 @test "run experiment with failing runner and empty array - return PASSED" {
-  array=(1 2)
+  # given
+  array=()
+  expected="$(jq -nc '{testResult: "PASSED"}')"
 
-  if runChaosExperiments failFunction "${array[@]}";
-  then
-    exit 1 # unexpected
-  fi
+  # when
+  result=$(runChaosExperiments failFunction "${array[@]}")
 
-  echo "expected"
+  # then
+  echo "actual: $result"
+  echo "expected: $expected"
+  [ "$result" == "$expected" ]
 }
 
 @test "create failure message without args" {

--- a/core/chaos-workers/handleJobTest.sh
+++ b/core/chaos-workers/handleJobTest.sh
@@ -9,20 +9,17 @@
 }
 
 
-variables="{
-  \"authenticationDetails\":{
-    \"audience\":\"33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com\",
-    \"authorizationURL\":\"https://login.cloud.ultrawombat.com/oauth/token\",
-    \"clientId\":\"-M-bpgPX7bkW8ssgeuuQof5obhNQgr.O\",
-    \"clientSecret\":\"~EfHvmjQFd4vIViilACpHSOz7IiJrMr~QgoNtDxlvhXbhlvkKut80.joW3On1zb4\",
-    \"contactPoint\":\"33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com:443\"
-  },
-\"clusterPlan\":\"Production - M\",
-\"testResult\":\"PASSED\",
-\"testParams\":{},
-\"clusterId\":\"33c00aed-cf34-4c8a-867d-161ee9c8943d\"
-}"
-
+ZEEBE_ADDRESS='33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com:443'
+ZEEBE_CLIENT_ID='-M-bpgPX7bkW8ssgeuuQof5obhNQgr.O'
+ZEEBE_CLIENT_SECRET='~EfHvmjQFd4vIViilACpHSOz7IiJrMr~QgoNtDxlvhXbhlvkKut80.joW3On1zb4'
+ZEEBE_AUTHORIZATION_SERVER_URL='https://login.cloud.ultrawombat.com/oauth/token'
+variables=$(jq -n \
+             --arg clientId "$ZEEBE_CLIENT_ID" \
+             --arg clientSecret "$ZEEBE_CLIENT_SECRET" \
+             --arg contactPoint "$ZEEBE_ADDRESS" \
+             --arg authorizationURL "$ZEEBE_AUTHORIZATION_SERVER_URL" \
+             --arg clusterId "${ZEEBE_ADDRESS%.zeebe.*}" \
+             '{authenticationDetails: {authorizationURL: $authorizationURL, contactPoint: $contactPoint, clientId: $clientId, clientSecret: $clientSecret}, clusterPlan: "Production - M", clusterId: $clusterId}')
 
 @test "extract cluster plan" {
   result=$(extractClusterPlan "$variables")

--- a/core/chaos-workers/handleJobTest.sh
+++ b/core/chaos-workers/handleJobTest.sh
@@ -8,10 +8,9 @@
   [ "$result" == "HELLO" ]
 }
 
-
-ZEEBE_ADDRESS='33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com:443'
-ZEEBE_CLIENT_ID='-M-bpgPX7bkW8ssgeuuQof5obhNQgr.O'
-ZEEBE_CLIENT_SECRET='~EfHvmjQFd4vIViilACpHSOz7IiJrMr~QgoNtDxlvhXbhlvkKut80.joW3On1zb4'
+ZEEBE_ADDRESS='address.zeebe.ultrawombat.com:443'
+ZEEBE_CLIENT_ID='ID_CLIENT'
+ZEEBE_CLIENT_SECRET='SECRET_CLIENT'
 ZEEBE_AUTHORIZATION_SERVER_URL='https://login.cloud.ultrawombat.com/oauth/token'
 variables=$(jq -n \
              --arg clientId "$ZEEBE_CLIENT_ID" \
@@ -30,13 +29,13 @@ variables=$(jq -n \
 @test "extract client id" {
   result=$(extractClientId "$variables")
   echo "$result"
-  [ "$result" == "-M-bpgPX7bkW8ssgeuuQof5obhNQgr.O" ]
+  [ "$result" == "ID_CLIENT" ]
 }
 
 @test "extract client secret" {
   result=$(extractClientSecret "$variables")
   echo "$result"
-  [ "$result" == "~EfHvmjQFd4vIViilACpHSOz7IiJrMr~QgoNtDxlvhXbhlvkKut80.joW3On1zb4" ]
+  [ "$result" == "SECRET_CLIENT" ]
 }
 
 @test "extract authorization server url" {
@@ -48,14 +47,13 @@ variables=$(jq -n \
 @test "extract zeebe address" {
   result=$(extractZeebeAddress "$variables")
   echo "$result"
-  [ "$result" == "33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com:443" ]
+  [ "$result" == "address.zeebe.ultrawombat.com:443" ]
 }
-
 
 @test "extract target namespace" {
   result=$(extractTargetNamespace "$variables")
   echo "$result"
-  [ "$result" == "33c00aed-cf34-4c8a-867d-161ee9c8943d-zeebe" ]
+  [ "$result" == "address-zeebe" ]
 }
 
 noop() { :;}

--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -70,12 +70,13 @@ extractTargetNamespace() {
 createFailureMessage() {
   result=FAILED
   args=( "$@" ) # get arguments as array
+  printf -v joined '%s,' "${args[@]}"
 
   # generate json result
   jq -n \
      --arg result "$result" \
-     --arg failures "${args[*]}" \
-     '{testResult: $result, failureMessages: $failures | split(" "), failureCount: 1, metaData: {}}'
+     --arg failures "${joined%,}" \
+     '{testResult: $result, failureMessages: $failures | split(","), failureCount: 1, metaData: {}}'
 }
 
 ################################################################################
@@ -95,7 +96,7 @@ runChaosExperiments() {
     then
       resultMsg=$(createFailureMessage "$experiment failed")
       echo "$resultMsg"
-      return 1
+      return 0 # if we return an error code the job worker would fail the job
     fi
   done
 

--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -68,10 +68,17 @@ extractTargetNamespace() {
 #}
 
 createFailureMessage() {
-  result=FAILED
+  # Input is expected to be an array of values.
+  # Possible inputs are for example: ("Namespace not found" "Other Error")
+  # In order to convert them to an json array we join them first together as one string, with comma as separator.
+  # Result would be: "Namespace not found, Other Error". This makes it possible to use the jq split function,
+  # which converts the string to a correct json array: [ "Namespace not found", "Other Error" ].
+  # Previous we just split them on whitespaces, but this lead to problems on inputs with whitespaces.
+  # Because they then have be converted to: [ "Namespace", "not", "found", "Other", "Error" ].
   args=( "$@" ) # get arguments as array
   printf -v joined '%s,' "${args[@]}"
 
+  result=FAILED
   # generate json result
   jq -n \
      --arg result "$result" \

--- a/core/chaos-workers/runWorker.sh
+++ b/core/chaos-workers/runWorker.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -euox pipefail
 
-# verify whether kube was correctly configured
-ls -la ~/.kube
-cat ~/.kube/config
-
 # DEBUG: PRINTS TOPOLOGY
 zbctl status
 

--- a/core/chaos-workers/runWorker.sh
+++ b/core/chaos-workers/runWorker.sh
@@ -8,18 +8,5 @@ cat ~/.kube/config
 # DEBUG: PRINTS TOPOLOGY
 zbctl status
 
-# DEBUG: DEPLOY WORKFLOW
-# scriptPath=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-# zbctl deploy "$scriptPath/../../workflows/chaos-test.bpmn"
-
-# DEBUG: CREATE NEW WORKFLOW INSTANCE
-# zbctl create instance chaos-test --variables "{
-#  \"authenticationDetails\":{\"audience\":\"33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com\",\"authorizationURL\":\"https://login.cloud.ultrawombat.com/oauth/token\",\"clientId\":\"-M-bpgPX7bkW8ssgeuuQof5obhNQgr.O\",\"clientSecret\":\"~EfHvmjQFd4vIViilACpHSOz7IiJrMr~QgoNtDxlvhXbhlvkKut80.joW3On1zb4\",\"contactPoint\":\"33c00aed-cf34-4c8a-867d-161ee9c8943d.zeebe.ultrawombat.com:443\"},
-#\"testReport\":{\"testResult\":\"PASSED\",\"startTime\":1603438963772,\"endTime\":1603438989088,\"timeOfFirstFailure\":0,\"failureCount\":0,\"failureMessages\":[],\"metaData\":{\"testParams\":{\"steps\":3,\"iterations\":10,\"maxTimeForIteration\":\"PT10S\",\"maxTimeForCompleteTest\":\"PT2M\"}},\"duration\":25316},
-#\"clusterPlan\":\"Production-M\",
-#\"testResult\":\"PASSED\",
-#\"testParams\":{\"maxTimeForCompleteTest\":\"PT2M\",\"maxTimeForIteration\":\"PT10S\",\"iterations\":10,\"steps\":3}
-#}"
-
 # Registers worker - will run `handleJob.sh` for each new job
 zbctl create worker chaos-experiments --handler handleJob.sh


### PR DESCRIPTION
I did more a integration test with the simple monitor and a camunda cloud cluster, which I created manually. In the end I was able to run a chaos experiment based on the given payload and complete the job successfully. There were a lot of failed and retried jobs in between :sweat_smile: 

![run](https://user-images.githubusercontent.com/2758593/98699336-52132980-2377-11eb-9232-461e13e5215a.png)

Cleaned up the worker script. I have a local script to run tests against simple monitor.
Fixes some problems in the job handler code.
 The runChaosExperiments has returned an positive value, which causes the job worker to fail the job and retry, which we don't want. The generation of the test result hasn't worked 100% correct. If the message contained white spaces it was also splitted in separate entries. Previous we haven't read the input correctly, since we used the wrong function.
