### PR TITLE
chore(ci): add optional deployment to dev stage

### DIFF
--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -18,7 +18,7 @@ elif [ "${tag}" = "dev" ]; then
   echo "Deploying :dev to 'dev' stage / 'testbench-dev' namespace"  
   suffix="-dev"
 else 
-  echo "Unknown tag '${tag}'"
+  echo "Unknown tag '${tag}'. Please provide the tag 'dev' or 'latest'"
   exit 1
 fi  
 

--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -2,11 +2,36 @@
 
 set -ex
 
+if [ -z "$1" ]
+then
+  echo "Please provide the tag 'dev' or 'latest'"
+  exit 1
+fi
+
+
+tag=$1
+
+if [ "${tag}" = "latest" ]; then
+  echo "Deploying :latest to 'int' stage / 'testbench' namespace"  
+  suffix=""
+elif [ "${tag}" = "dev" ]; then
+  echo "Deploying :dev to 'dev' stage / 'testbench-dev' namespace"  
+  suffix="-dev"
+else 
+  echo "Unknown tag '${tag}'"
+  exit 1
+fi  
+
+echo "suffix: ${suffix}"
+
+namespace="testbench${suffix}"
+echo "target namespace: ${namespace}"
+
 gcloud config set core/project zeebe-io
 gcloud config set compute/region europe-west1
 gcloud config set compute/zone europe-west1-b
 
-set +x; echo ${SA_CREDENTIALS} > sa-credentials.json; set -x
+set +x; echo "${SA_CREDENTIALS}" > sa-credentials.json; set -x
 
 gcloud auth activate-service-account jenkins-ci-cd@zeebe-io.iam.gserviceaccount.com --key-file=sa-credentials.json
 
@@ -15,15 +40,15 @@ rm sa-credentials.json
 gcloud container clusters get-credentials zeebe-cluster
 
 # apply changes to testbench.yaml, if any
-kubectl apply --namespace=testbench -f testbench.yaml
+kubectl apply --namespace="${namespace}" -f "testbench${suffix}.yaml"
 
 # apply changes to chaosWorker.yaml, if any
-kubectl apply --namespace=testbench -f core/chaos-workers/chaosWorker.yaml
+kubectl apply --namespace="${namespace}" -f "core/chaos-workers/chaosWorker${suffix}.yaml"
 
 # trigger restart to load newest version of the image 
-kubectl rollout restart deployment testbench --namespace=testbench
-kubectl rollout restart deployment chaos-worker --namespace=testbench
+kubectl rollout restart deployment testbench --namespace="${namespace}"
+kubectl rollout restart deployment chaos-worker --namespace="${namespace}"
 
 # wait for pods getting started
-kubectl wait --for=condition=Ready pod -l app=testbench --timeout=180s --namespace=testbench
-kubectl wait --for=condition=Ready pod -l app=chaos-worker --timeout=180s --namespace=testbench
+kubectl wait --for=condition=Ready pod -l app=testbench --timeout=180s --namespace="${namespace}"
+kubectl wait --for=condition=Ready pod -l app=chaos-worker --timeout=180s --namespace="${namespace}"

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,5 @@ indent_size = 2
 [*.md]
 indent_size = 2
 
-[*.dsl,*.groovy,Jenkinsfile*]
+[Jenkinsfile*]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+
+[*]
+indent_style = space
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.xml]
+indent_size = 2
+
+[*.html]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+
+[*.dsl,*.groovy,Jenkinsfile*]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ buildNumber.properties
 *.iml
 config.properties
 /secrets.yaml
+/secrets-dev.yaml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,211 +6,211 @@ def buildName = "${env.JOB_BASE_NAME.replaceAll("%2F", "-").replaceAll("\\.", "-
 
 pipeline {
 
-  agent {
-    kubernetes {
-      cloud 'zeebe-ci'
-      label "zeebe-ci-build_${buildName}"
-      defaultContainer 'jnlp'
-      yamlFile '.ci/podSpecs/distribution.yml'
+    agent {
+        kubernetes {
+            cloud 'zeebe-ci'
+            label "zeebe-ci-build_${buildName}"
+            defaultContainer 'jnlp'
+            yamlFile '.ci/podSpecs/distribution.yml'
+        }
     }
-  }
 
-  options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
-    timestamps()
-    timeout(time: 15, unit: 'MINUTES')
-  }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timestamps()
+        timeout(time: 15, unit: 'MINUTES')
+    }
 
-  environment {
-    NEXUS = credentials("camunda-nexus")
-    DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
-    SA_CREDENTIALS = credentials("zeebe-jenkins-deploy-serviceaccount-json")
-  }
+    environment {
+        NEXUS = credentials("camunda-nexus")
+        DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
+        SA_CREDENTIALS = credentials("zeebe-jenkins-deploy-serviceaccount-json")
+    }
 
-  parameters {
-    booleanParam(name: 'DEPLOY_TO_DEV', defaultValue: false, description: 'Should this version be deployed to dev stage (by default master will deploy to int stage; other branches do not deploy at all)');
-    booleanParam(name: 'RELEASE', defaultValue: false, description: 'Build a release from current commit?')
-    string(name: 'RELEASE_VERSION', defaultValue: '0.X.0', description: 'Which version to release?')
-    string(name: 'DEVELOPMENT_VERSION', defaultValue: '0.Y.0-SNAPSHOT', description: 'Next development version?')
-  }
+    parameters {
+        booleanParam(name: 'DEPLOY_TO_DEV', defaultValue: false, description: 'Should this version be deployed to dev stage (by default master will deploy to int stage; other branches do not deploy at all)');
+        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Build a release from current commit?')
+        string(name: 'RELEASE_VERSION', defaultValue: '0.X.0', description: 'Which version to release?')
+        string(name: 'DEVELOPMENT_VERSION', defaultValue: '0.Y.0-SNAPSHOT', description: 'Next development version?')
+    }
 
-  stages {
-    stage('Prepare') {
-      steps {
-        script {
-            commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
-            displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+    stages {
+        stage('Prepare') {
+        steps {
+            script {
+                commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
+                displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
 
-            if (displayNameFull.length() <= 45) {
-              currentBuild.displayName = displayNameFull
-            } else {
-              displayStringHardTruncate = displayNameFull.take(45)
-              currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                if (displayNameFull.length() <= 45) {
+                    currentBuild.displayName = displayNameFull
+                } else {
+                    displayStringHardTruncate = displayNameFull.take(45)
+                    currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                }
+            }
+            container('maven') {
+                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                    sh '.ci/scripts/distribution/prepare.sh'
+                }
             }
         }
-        container('maven') {
-          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-            sh '.ci/scripts/distribution/prepare.sh'
-          }
         }
-      }
-    }
 
-    stage('Build') {
-      steps {
-        container('maven') {
-          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-            sh 'mvn install -B -s $MAVEN_SETTINGS_XML -Dsurefire.rerunFailingTestsCount=5'
-          }
+        stage('Build') {
+        steps {
+            container('maven') {
+                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                    sh 'mvn install -B -s $MAVEN_SETTINGS_XML -Dsurefire.rerunFailingTestsCount=5'
+                }
+            }
         }
-      }
 
-      post {
-        always {
-            junit testResults: "**/*/surefire-reports/TEST-*.xml", keepLongStdio: true
-            // junit testResults: "**/*/failsafe-reports/TEST-*.xml", keepLongStdio: true
+        post {
+            always {
+                junit testResults: "**/*/surefire-reports/TEST-*.xml", keepLongStdio: true
+                // junit testResults: "**/*/failsafe-reports/TEST-*.xml", keepLongStdio: true
 
-            jacoco(
-                  execPattern: '**/*.exec',
-                  classPattern: '**/target/classes',
-                  sourcePattern: '**/src/main/java',
-                  runAlways: true
-            )
-            zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
+                jacoco(
+                    execPattern: '**/*.exec',
+                    classPattern: '**/target/classes',
+                    sourcePattern: '**/src/main/java',
+                    runAlways: true
+                )
+                zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
+            }
+            failure {
+                zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
+                archive "**/hs_err_*.log"
+            }
         }
-        failure {
-            zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
-            archive "**/hs_err_*.log"
         }
-      }
-    }
 
-    stage('Verify scripts') {
-      steps {
-          container('maven') {
-              dir('core/chaos-workers') {
-                  println("Check all chaos script`s with shellcheck (linter).")
-                  sh 'shellcheck -x *.sh'
-                  println("Scripts are fine.")
-                  println("Run bash tests via bats.")
-                  sh './*Test.sh'
-              }
-          }
-      }
-    }
-
-    stage('Upload') {
-      when {
-      	not { expression { params.RELEASE } }
-      	branch 'master'
-      }
-      steps {
-        container('maven') {
-          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-            sh 'mvn -B -s $MAVEN_SETTINGS_XML generate-sources source:jar javadoc:jar deploy -DskipTests'
-          }
+        stage('Verify scripts') {
+        steps {
+            container('maven') {
+                dir('core/chaos-workers') {
+                    println("Check all chaos script`s with shellcheck (linter).")
+                    sh 'shellcheck -x *.sh'
+                    println("Scripts are fine.")
+                    println("Run bash tests via bats.")
+                    sh './*Test.sh'
+                }
+            }
         }
-      }
-    }
+        }
 
-    stage('Deploy') {
-    	when {
-    	   anyOf {
-    	       branch 'master'
-    	       expression { params.DEPLOY_TO_DEV }
-    	   }
-    	}
+        stage('Upload') {
+        when {
+            not { expression { params.RELEASE } }
+            branch 'master'
+        }
+        steps {
+            container('maven') {
+                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                    sh 'mvn -B -s $MAVEN_SETTINGS_XML generate-sources source:jar javadoc:jar deploy -DskipTests'
+                }
+            }
+        }
+        }
+
+        stage('Deploy') {
+            when {
+                anyOf {
+                    branch 'master'
+                    expression { params.DEPLOY_TO_DEV }
+                }
+            }
+
+            environment {
+                TAG = getTag()
+            }
+
+            steps {
+                container('docker') {
+                    /* this command is a little convoluted to avoid leaking of the secret;
+                    * it is unclear why the built-in Jenkins mechanism doesn't work out of the box
+                    */
+                    sh 'set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x'
+
+                    sh "docker build -t gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG} ."
+                    sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG}"
+                    withVault([vaultSecrets: [
+                            [path: 'secret/common/ci-zeebe/zeebe-chaos-service-account', secretValues: [
+                                    [vaultKey: 'token'],
+                            ]],
+                    ]]) {
+
+                        dir('core/chaos-workers/') {
+                            sh "docker build . -t gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG} --build-arg TOKEN=${env.token}"
+                            sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG}"
+                        }
+                    }
+                }
+
+
+                container('gcloud') {
+                    sh '.ci/scripts/prepare-deploy.sh'
+                    sh ".ci/scripts/deploy.sh ${env.TAG}"
+                }
+            }
+        }
+
+        stage('Release') {
+        when { expression { params.RELEASE } }
 
         environment {
-            TAG = getTag()
+            MAVEN_CENTRAL = credentials('maven_central_deployment_credentials')
+            GPG_PASS = credentials('password_maven_central_gpg_signing_key')
+            GPG_PUB_KEY = credentials('maven_central_gpg_signing_key_pub')
+            GPG_SEC_KEY = credentials('maven_central_gpg_signing_key_sec')
+            GITHUB_TOKEN = credentials('camunda-jenkins-github')
+            RELEASE_VERSION = "${params.RELEASE_VERSION}"
+            DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
         }
 
-    	steps {
-    		container('docker') {
-    			/* this command is a little convoluted to avoid leaking of the secret;
-    			 * it is unclear why the built-in Jenkins mechanism doesn't work out of the box
-    			 */
-	          	sh 'set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x'
-
-    			sh "docker build -t gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG} ."
-    			sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG}"
-                withVault([vaultSecrets: [
-                        [path: 'secret/common/ci-zeebe/zeebe-chaos-service-account', secretValues: [
-                                [vaultKey: 'token'],
-                        ]],
-                ]]) {
-
-                  dir('core/chaos-workers/') {
-                    sh "docker build . -t gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG} --build-arg TOKEN=${env.token}"
-                    sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG}"
-                  }
+        steps {
+            container('maven') {
+                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                    sshagent(['camunda-jenkins-github-ssh']) {
+                        sh 'gpg -q --import ${GPG_PUB_KEY} '
+                        sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
+                        sh 'git config --global user.email "ci@camunda.com"'
+                        sh 'git config --global user.name "camunda-jenkins"'
+                        sh 'mkdir ~/.ssh/ && ssh-keyscan github.com >> ~/.ssh/known_hosts'
+                        sh 'mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar javadoc:jar release:prepare release:perform -Prelease'
+                        sh '.ci/scripts/github-release.sh'
+                    }
                 }
-    		}
-
-
-    		container('gcloud') {
-                sh '.ci/scripts/prepare-deploy.sh'
-                sh ".ci/scripts/deploy.sh ${env.TAG}"
-    		}
-    	}
-    }
-
-    stage('Release') {
-      when { expression { params.RELEASE } }
-
-      environment {
-        MAVEN_CENTRAL = credentials('maven_central_deployment_credentials')
-        GPG_PASS = credentials('password_maven_central_gpg_signing_key')
-        GPG_PUB_KEY = credentials('maven_central_gpg_signing_key_pub')
-        GPG_SEC_KEY = credentials('maven_central_gpg_signing_key_sec')
-        GITHUB_TOKEN = credentials('camunda-jenkins-github')
-        RELEASE_VERSION = "${params.RELEASE_VERSION}"
-        DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
-      }
-
-      steps {
-        container('maven') {
-          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-              sshagent(['camunda-jenkins-github-ssh']) {
-                sh 'gpg -q --import ${GPG_PUB_KEY} '
-                sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
-                sh 'git config --global user.email "ci@camunda.com"'
-                sh 'git config --global user.name "camunda-jenkins"'
-                sh 'mkdir ~/.ssh/ && ssh-keyscan github.com >> ~/.ssh/known_hosts'
-                sh 'mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar javadoc:jar release:prepare release:perform -Prelease'
-                sh '.ci/scripts/github-release.sh'
-             }
-          }
+            }
         }
-      }
+        }
     }
-  }
 
-  post {
-      always {
-          // Retrigger the build if the node disconnected
-          script {
-              if (agentDisconnected()) {
+    post {
+        always {
+            // Retrigger the build if the node disconnected
+            script {
+                if (agentDisconnected()) {
                     currentBuild.result = 'ABORTED'
                     currentBuild.description = "Aborted due to connection error"
-                  build job: currentBuild.projectName, propagate: false, quietPeriod: 20, wait: false
-              }
-          }
-      }
-
-    failure {
-        script {
-            if (env.BRANCH_NAME != 'master' || agentDisconnected()) {
-                return
+                    build job: currentBuild.projectName, propagate: false, quietPeriod: 20, wait: false
+                }
             }
-
-            slackSend(
-                channel: "#zeebe-testbench-ci",
-                message: "Zeebe Cluster Testbench failed on ${env.BRANCH_NAME} for build ${currentBuild.absoluteUrl}"
-           )
         }
-      }
-  }
+
+        failure {
+            script {
+                if (env.BRANCH_NAME != 'master' || agentDisconnected()) {
+                    return
+                }
+
+                slackSend(
+                    channel: "#zeebe-testbench-ci",
+                    message: "Zeebe Cluster Testbench failed on ${env.BRANCH_NAME} for build ${currentBuild.absoluteUrl}"
+            )
+            }
+        }
+    }
 }
 
 def getTag() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,9 @@ pipeline {
     }
 
     environment {
-        NEXUS = credentials("camunda-nexus")
-        DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
-        SA_CREDENTIALS = credentials("zeebe-jenkins-deploy-serviceaccount-json")
+        NEXUS = credentials('camunda-nexus')
+        DOCKER_GCR = credentials('zeebe-gcr-serviceaccount-json')
+        SA_CREDENTIALS = credentials('zeebe-jenkins-deploy-serviceaccount-json')
     }
 
     parameters {
@@ -39,13 +39,13 @@ pipeline {
         steps {
             script {
                 commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
-                displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+                displayNameFull = '#' + BUILD_NUMBER + ': ' + commit_summary
 
                 if (displayNameFull.length() <= 45) {
                     currentBuild.displayName = displayNameFull
                 } else {
                     displayStringHardTruncate = displayNameFull.take(45)
-                    currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                    currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(' '))
                 }
             }
             container('maven') {
@@ -67,8 +67,8 @@ pipeline {
 
         post {
             always {
-                junit testResults: "**/*/surefire-reports/TEST-*.xml", keepLongStdio: true
-                // junit testResults: "**/*/failsafe-reports/TEST-*.xml", keepLongStdio: true
+                junit testResults: '**/*/surefire-reports/TEST-*.xml', keepLongStdio: true
+                // junit testResults: '**/*/failsafe-reports/TEST-*.xml', keepLongStdio: true
 
                 jacoco(
                     execPattern: '**/*.exec',
@@ -76,11 +76,11 @@ pipeline {
                     sourcePattern: '**/src/main/java',
                     runAlways: true
                 )
-                zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
+                zip zipFile: 'test-coverage-reports.zip', archive: true, glob: '**/target/site/jacoco/**'
             }
             failure {
-                zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
-                archive "**/hs_err_*.log"
+                zip zipFile: 'test-reports.zip', archive: true, glob: '**/*/surefire-reports/**'
+                archive '**/hs_err_*.log'
             }
         }
         }
@@ -132,8 +132,8 @@ pipeline {
                     */
                     sh 'set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x'
 
-                    sh "docker build -t gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG} ."
-                    sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench:${env.TAG}"
+                    sh 'docker build -t gcr.io/zeebe-io/zeebe-cluster-testbench:${TAG} .'
+                    sh 'docker push gcr.io/zeebe-io/zeebe-cluster-testbench:${TAG}'
                     withVault([vaultSecrets: [
                             [path: 'secret/common/ci-zeebe/zeebe-chaos-service-account', secretValues: [
                                     [vaultKey: 'token'],
@@ -141,8 +141,8 @@ pipeline {
                     ]]) {
 
                         dir('core/chaos-workers/') {
-                            sh "docker build . -t gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG} --build-arg TOKEN=${env.token}"
-                            sh "docker push gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${env.TAG}"
+                            sh 'docker build . -t gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${TAG} --build-arg TOKEN=${token}'
+                            sh 'docker push gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:${TAG}'
                         }
                     }
                 }
@@ -150,7 +150,7 @@ pipeline {
 
                 container('gcloud') {
                     sh '.ci/scripts/prepare-deploy.sh'
-                    sh ".ci/scripts/deploy.sh ${env.TAG}"
+                    sh '.ci/scripts/deploy.sh ${TAG}'
                 }
             }
         }
@@ -192,7 +192,7 @@ pipeline {
             script {
                 if (agentDisconnected()) {
                     currentBuild.result = 'ABORTED'
-                    currentBuild.description = "Aborted due to connection error"
+                    currentBuild.description = 'Aborted due to connection error'
                     build job: currentBuild.projectName, propagate: false, quietPeriod: 20, wait: false
                 }
             }
@@ -205,7 +205,7 @@ pipeline {
                 }
 
                 slackSend(
-                    channel: "#zeebe-testbench-ci",
+                    channel: '#zeebe-testbench-ci',
                     message: "Zeebe Cluster Testbench failed on ${env.BRANCH_NAME} for build ${currentBuild.absoluteUrl}"
             )
             }
@@ -214,5 +214,5 @@ pipeline {
 }
 
 def getTag() {
-    return params.DEPLOY_TO_DEV ? "dev" : "latest"
+    return params.DEPLOY_TO_DEV ? 'dev' : 'latest'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
     booleanParam(name: 'DEPLOY_TO_DEV', defaultValue: false, description: 'Should this version be deployed to dev stage (by default master will deploy to int stage; other branches do not deploy at all)');
     booleanParam(name: 'RELEASE', defaultValue: false, description: 'Build a release from current commit?')
     string(name: 'RELEASE_VERSION', defaultValue: '0.X.0', description: 'Which version to release?')
-    string(name: 'DEVELOPMENT_VERSION', defaultValue: '0.Y.0-SNAPSHOT', description: 'Next development version?')    
+    string(name: 'DEVELOPMENT_VERSION', defaultValue: '0.Y.0-SNAPSHOT', description: 'Next development version?')
   }
 
   stages {
@@ -114,15 +114,15 @@ pipeline {
     }
 
     stage('Deploy') {
-    	when { 
+    	when {
     	   anyOf {
     	       branch 'master'
     	       expression { params.DEPLOY_TO_DEV }
-    	   } 
+    	   }
     	}
-    	
+
         environment {
-            TAG = getTag()            
+            TAG = getTag()
         }
 
     	steps {
@@ -194,21 +194,21 @@ pipeline {
                     currentBuild.result = 'ABORTED'
                     currentBuild.description = "Aborted due to connection error"
                   build job: currentBuild.projectName, propagate: false, quietPeriod: 20, wait: false
-              }                     
+              }
           }
       }
-      
+
     failure {
         script {
             if (env.BRANCH_NAME != 'master' || agentDisconnected()) {
                 return
             }
-           
-            slackSend( 
+
+            slackSend(
                 channel: "#zeebe-testbench-ci",
                 message: "Zeebe Cluster Testbench failed on ${env.BRANCH_NAME} for build ${currentBuild.absoluteUrl}"
-           )    
-        }       
+           )
+        }
       }
   }
 }

--- a/core/chaos-workers/chaosWorker-dev.yaml
+++ b/core/chaos-workers/chaosWorker-dev.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaos-worker
+  labels:
+    app: chaos-worker
+spec:
+  selector:
+    matchLabels:
+      app: chaos-worker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: chaos-worker
+    spec:
+      containers:
+      - name: chaos-worker
+        image: gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:dev
+        imagePullPolicy: Always
+        env:
+          - name: ZEEBE_AUTHORIZATION_SERVER_URL
+            value: "https://login.cloud.dev.ultrawombat.com/oauth/token"
+          - name: ZEEBE_CLIENT_ID
+            value: "cOf2ryfrDoCaHqXFwrQm7y7n9yEP4Imp"
+          - name: ZEEBE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: testbench-secrets
+                key: clientSecret
+          - name: ZEEBE_ADDRESS
+            valueFrom:
+              secretKeyRef:
+                name: testbench-secrets
+                key: contactPoint
+        resources:
+          limits:
+            cpu: 4
+            memory: 256Mi
+          requests:
+            cpu: 2
+            memory: 100Mi

--- a/testbench-dev.yaml
+++ b/testbench-dev.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testbench
+  labels:
+    app: testbench
+spec:
+  selector:
+    matchLabels:
+      app: testbench
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: testbench
+    spec:
+      containers:
+        - name: testbench
+          image: gcr.io/zeebe-io/zeebe-cluster-testbench:dev
+          imagePullPolicy: Always
+          env:
+            - name: ZCTB_AUTHENTICATION_SERVER_URL
+              value: "https://login.cloud.dev.ultrawombat.com/oauth/token"
+            - name: ZCTB_CLIENT_ID
+              value: "cOf2ryfrDoCaHqXFwrQm7y7n9yEP4Imp"
+            - name: ZCTB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: clientSecret
+            - name: ZCTB_CONTACT_POINT
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: contactPoint
+            - name: ZCTB_CLOUD_API_URL
+              value: "https://console.cloud.dev.ultrawombat.com/customer-api/"
+            - name: ZCTB_CLOUD_AUDIENCE
+              value: "api.cloud.dev.ultrawombat.com"
+            - name: ZCTB_CLOUD_AUTHENTICATION_SERVER_URL
+              value: "https://login.cloud.dev.ultrawombat.com/oauth/token"
+            - name: ZCTB_CLOUD_CLIENT_ID
+              value: "VfebeBObQjDo~uPN"
+            - name: ZCTB_CLOUD_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: cloudClientSecret
+            - name: ZCTB_INTERNAL_CLOUD_AUTHENTICATION_SERVER_URL
+              value: "https://weblogin.cloud.dev.ultrawombat.com/oauth/token"
+            - name: ZCTB_INTERNAL_CLOUD_API_URL
+              value: "https://console.cloud.dev.ultrawombat.com/"
+            - name: ZCTB_INTERNAL_CLOUD_AUDIENCE
+              value: "cloud.dev.ultrawombat.com"
+            - name: ZCTB_INTERNAL_CLOUD_CLIENT_ID
+              value: "JwL6DqOVmmROA3DGXXqyDyU1BJ5FCfM5"
+            - name: ZCTB_INTERNAL_CLOUD_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: internalCloudClientSecret
+            - name: ZCTB_INTERNAL_CLOUD_USERNAME
+              value: "zeebe@camunda.com"
+            - name: ZCTB_INTERNAL_CLOUD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: internalCloudPassword
+            - name: ZCTB_SHEETS_API_KEYFILE_CONTENT
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: sheetsApiKeyfileContent
+            - name: ZCTB_REPORT_SHEET_ID
+              value: "1l3ofIIHKHWTjRs1IpZYl1ULMfqkyGpL7JRarkR0of94"
+            - name: ZCTB_SLACK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: slackToken
+            - name: ZCTB_SLACK_CHANNEL
+              value: "#slack-bot-dev"
+          resources:
+            limits:
+              cpu: 4
+              memory: 256Mi
+            requests:
+              cpu: 2
+              memory: 100Mi


### PR DESCRIPTION
closes #100 

This adds a build parameter "DEPLOY_TO_DEV"

When this is set:
* the image will be tagged with `:dev`
* all artifacts will be deployed into the namespace `testbench-dev`
* for all artifacts the deployment descriptor `...-dev.yaml` will be used

When this is not set and we are on the master, it will continue deploy the `:latest` image to `testbench` namespace as usual.

Enabling "DEPLOY_TO_DEV" on master is also possible and will deploy to dev. One use case of this could be to overwrite a bad deployment on dev.