### PR TITLE
fix(chaos): use correct json template

### DIFF
--- a/core/chaos-workers/handleJobTest.sh
+++ b/core/chaos-workers/handleJobTest.sh
@@ -79,7 +79,7 @@ failFunction() {
 @test "run experiment with failing runner and values in array - return FAILED" {
   # given
   array=(1 2)
-  expected="$(jq -n '{testResult: "FAILED", failureMessages: ["1 failed"], failureCount: 1, metaData: {}}')"
+  expected="$(jq -n '{testResult: "FAILED", testReport: {testResult: "FAILED", failureMessages: ["1 failed"], failureCount: 1, metaData: {}}}')"
 
   # when
   result=$(runChaosExperiments failFunction "${array[@]}")
@@ -106,7 +106,7 @@ failFunction() {
 
 @test "create failure message without args" {
   # given
-  expected="$(jq -n '{testResult: "FAILED", failureMessages: [], failureCount: 1, metaData: {}}')"
+  expected="$(jq -n '{testResult: "FAILED", testReport: {testResult: "FAILED", failureMessages: [], failureCount: 1, metaData: {}}}')"
 
   # when
   failureMsg=$(createFailureMessage)
@@ -119,7 +119,7 @@ failFunction() {
 
 @test "create failure message with number as one arg" {
   # given
-  expected="$(jq -n '{testResult: "FAILED", failureMessages: ["2"], failureCount: 1, metaData: {}}')"
+  expected="$(jq -n '{testResult: "FAILED", testReport: {testResult: "FAILED", failureMessages: ["2"], failureCount: 1, metaData: {}}}')"
 
   # when
   failureMsg=$(createFailureMessage 2)
@@ -132,7 +132,7 @@ failFunction() {
 
 @test "create failure message with string as one arg" {
   # given
-  expected="$(jq -n '{testResult: "FAILED", failureMessages: ["2"], failureCount: 1, metaData: {}}')"
+  expected="$(jq -n '{testResult: "FAILED", testReport: {testResult: "FAILED", failureMessages: ["2"], failureCount: 1, metaData: {}}}')"
 
   # when
   failureMsg=$(createFailureMessage "2")
@@ -146,7 +146,7 @@ failFunction() {
 
 @test "create failure message with multiple fail messages" {
   # given
-  expected="$(jq -n '{testResult: "FAILED", failureMessages: ["2", "hallo"], failureCount: 1, metaData: {}}')"
+  expected="$(jq -n '{testResult: "FAILED", testReport: {testResult: "FAILED", failureMessages: ["2", "hallo"], failureCount: 1, metaData: {}}}')"
 
   # when
   failureMsg=$(createFailureMessage 2 "hallo")

--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -83,7 +83,7 @@ createFailureMessage() {
   jq -n \
      --arg result "$result" \
      --arg failures "${joined%,}" \
-     '{testResult: $result, failureMessages: $failures | split(","), failureCount: 1, metaData: {}}'
+     '{testResult: $result, testReport: {testResult: $result, failureMessages: $failures | split(","), failureCount: 1, metaData: {}}}'
 }
 
 ################################################################################


### PR DESCRIPTION
Fixes wrong json template.

**Before**:
```json
{
		"testResult": "FAILED",
		"failureCount": 1,
		"failureMessages": [],
		"metaData": {
		}
}
```
**After**:

```json
{
	"testResult": "FAILED",
	"testReport": {
		"testResult": "FAILED",
		"failureCount": 1,
		"failureMessages": [],
		"metaData": {
		}
	}
}

```

Ideally we could define the template in one place where java and script clients can take it from.

closes #117 