### PR TITLE
chore(chaos): dont fail test if files not exist

### DIFF
--- a/core/chaos-workers/handleJob.sh
+++ b/core/chaos-workers/handleJob.sh
@@ -53,8 +53,4 @@ export PATH
 # Get latest state of the repo
 git pull origin master &>> "$logFile"
 
-chaosRunner() {
-  chaos run "$1"
-}
-
 runChaosExperiments chaosRunner "$clusterPlan"/*/experiment.json

--- a/core/chaos-workers/handleJobTest.sh
+++ b/core/chaos-workers/handleJobTest.sh
@@ -104,6 +104,20 @@ failFunction() {
   [ "$result" == "$expected" ]
 }
 
+@test "chaos runner should not fail if no files exist" {
+  # given
+  array=()
+  expected="$(jq -nc '{testResult: "PASSED"}')"
+
+  # when
+  result=$(runChaosExperiments chaosRunner "/tmp/*/files")
+
+  # then
+  echo "actual: $result"
+  echo "expected: $expected"
+  [ "$result" == "$expected" ]
+}
+
 @test "create failure message without args" {
   # given
   expected="$(jq -n '{testResult: "FAILED", failureMessages: [], failureCount: 1, metaData: {}}')"
@@ -142,7 +156,6 @@ failFunction() {
   echo "expected: $expected"
   [ "$failureMsg" == "$expected" ]
 }
-
 
 @test "create failure message with multiple fail messages" {
   # given

--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -94,6 +94,13 @@ generateLogFileName() {
   echo "output-$(date +%Y%m%d).log"
 }
 
+chaosRunner() {
+  if [ -f "$1" ]
+  then
+    chaos run "$1"
+  fi
+}
+
 runChaosExperiments() {
   runner=$1
   # run all experiments for cluster plan


### PR DESCRIPTION
Previous tests have been failed because there were not experiments for development, production s etc in the github repo. In order to prevent that we check now whether files exist. If there are no experiments to execute the test is passed.