### PR TITLE
Persist chaos log

### DIFF
--- a/core/chaos-workers/chaosWorker.yaml
+++ b/core/chaos-workers/chaosWorker.yaml
@@ -1,3 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chaos-data-claim
+  labels:
+    app: chaos-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,3 +53,10 @@ spec:
           requests:
             cpu: 2
             memory: 100Mi
+        volumeMounts:
+        - name: data
+          mountPath: /home/chaos/data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: chaos-data-claim

--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -179,7 +179,7 @@ nowMs() {
 ################################################################################
 
 generateLogFileName() {
-  echo "output-$(date +%Y%m%d).log"
+  echo "/home/chaos/data/output-$(date +%Y%m%d).log"
 }
 
 chaosRunner() {


### PR DESCRIPTION
As stated in https://github.com/zeebe-io/zeebe-cluster-testbench/issues/139 it is not possible to use the handlers system out to log messages, which is the reason why we need to persist the log to a pvc to be resistant against pod restarts.

Data is stored under: `/home/chaos/data/`

**Example:**

```
bash-5.0# find /home/chaos/data/
/home/chaos/data/
/home/chaos/data/lost+found
/home/chaos/data/output-20201116.log
```

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/139


I will documented it as part of https://github.com/zeebe-io/zeebe-cluster-testbench/issues/87