### PR TITLE
Store chaostoolkit.log in pvc

### DIFF
--- a/core/chaos-workers/handlerUtil.sh
+++ b/core/chaos-workers/handlerUtil.sh
@@ -186,7 +186,8 @@ generateLogFileName() {
 chaosRunner() {
   if [ -f "$1" ]
   then
-    chaos run "$1"
+    logHome=${CHAOS_LOG_HOME:-"."}
+    chaos --log-file "$logHome/chaostoolkit.log" run "$1"
   fi
 }
 


### PR DESCRIPTION
Previous the `chaostoolkit.log` was not stored in the pvc only the output of chaostoolkit.