### PR TITLE
chore(chaos): use runChaos script

### DIFF
--- a/core/chaos-workers/handleJob.sh
+++ b/core/chaos-workers/handleJob.sh
@@ -46,18 +46,16 @@ kubectl get pods &>> "$logFile"
 
 cd "zeebe-chaos/chaos-experiments/camunda-cloud/" || exit 1
 
+# add scripts to path
+source runChaos.sh
+
 # deploy workers which are needed in some of our chaos experiments
 # Be aware that we are not delete them here, since if the experiments fails we might want to check
 # the logs of the workers AND they are deleted if we delete the namespace anyway.
 kubectl apply -f worker.yaml &>> "$logFile"
 
-# add scripts to path
-PATH="$PATH:$(pwd)/scripts/"
-export PATH
-
 # Get latest state of the repo
 git pull origin master &>> "$logFile"
-
 
 # We using a glob to get all experiments for a clusterplan, but if no files exist
 # the glob is replaced with itself. To avoid that we use nullglob, which will replace it with null.
@@ -66,7 +64,7 @@ git pull origin master &>> "$logFile"
 # Bash loop over a list of (non-existing) files https://www.endpoint.com/blog/2016/12/12/bash-loop-wildcards-nullglob-failglob
 # Shopts: https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
 #
-# This makes the implementation easier, since we get an empty array as parameter, which means we skip the execution and mark the job as skipped. 
+# This makes the implementation easier, since we get an empty array as parameter, which means we skip the execution and mark the job as skipped.
 shopt -s nullglob
 runChaosExperiments chaosRunner "$clusterPlan"/*/experiment.json
 shopt -u nullglob

--- a/core/chaos-workers/runChaos.sh
+++ b/core/chaos-workers/runChaos.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This is a place holder script to make shellcheck happy.
+# In the end we will use runChaos.sh from the zeebe-chaos repo


### PR DESCRIPTION
Uses the runChaos script to be more resistant against changes in the zeebe-chaos repo.
Previous it assumed a structure of the repo which might change as we did with zeebe-io/zeebe-chaos#44