### PR TITLE
chore(chaos): configure chaos worker

### DIFF
--- a/core/chaos-workers/runWorker.sh
+++ b/core/chaos-workers/runWorker.sh
@@ -5,4 +5,10 @@ set -euox pipefail
 zbctl status
 
 # Registers worker - will run `handleJob.sh` for each new job
-zbctl create worker chaos-experiments --handler handleJob.sh
+
+
+zbctl --insecure create worker chaos-experiments \
+      --concurrency 1 \
+      --maxJobsActive 1 \
+      --timeout $(( 1 * 60 * 60  ))s \
+      --handler handleJob.sh


### PR DESCRIPTION
Configures the chaos worker:

 * activates one job at a time
 * sets concurrency to 1
 * sets timeout to 1 hour