### PR TITLE
fix(chaos): remove insecure flag

### DIFF
--- a/core/chaos-workers/runWorker.sh
+++ b/core/chaos-workers/runWorker.sh
@@ -7,7 +7,7 @@ zbctl status
 # Registers worker - will run `handleJob.sh` for each new job
 
 
-zbctl --insecure create worker chaos-experiments \
+zbctl create worker chaos-experiments \
       --concurrency 1 \
       --maxJobsActive 1 \
       --timeout $(( 1 * 60 * 60  ))s \


### PR DESCRIPTION
I mistakenly added yesterday the insecure flag this is the reason why currently the worker doesnt connect :see_no_evil: sorry.