### PR TITLE
chore(workflows): add root workflow information

### DIFF
--- a/workflows/daily-test-protocol.bpmn
+++ b/workflows/daily-test-protocol.bpmn
@@ -13,6 +13,7 @@
           <zeebe:input source="=[&#34;Development&#34;, &#34;Production - S&#34;, &#34;Production - M&#34;, &#34;Production - L&#34;]" target="clusterPlans" />
           <zeebe:input source="={&#34;steps&#34;:3,&#34;iterations&#34;:10,&#34;maxTimeForIteration&#34;:&#34;PT10S&#34;,&#34;maxTimeForCompleteTest&#34;:&#34;PT2M&#34;}" target="sequentialTestParams" />
           <zeebe:input source="={}" target="chaosTestParams" />
+          <zeebe:input source="=&#34;Daily Test Protocol&#34;" target="rootWorkflow" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1gt1xs8</bpmn:incoming>

--- a/workflows/qa-protocol.bpmn
+++ b/workflows/qa-protocol.bpmn
@@ -15,6 +15,7 @@
           <zeebe:input source="=[&#34;Development&#34;, &#34;Production - S&#34;, &#34;Production - M&#34;, &#34;Production - L&#34;]" target="clusterPlans" />
           <zeebe:input source="={&#34;steps&#34;:3,&#34;iterations&#34;:10,&#34;maxTimeForIteration&#34;:&#34;PT10S&#34;,&#34;maxTimeForCompleteTest&#34;:&#34;PT2M&#34;}" target="sequentialTestParams" />
           <zeebe:input source="={}" target="chaosTestParams" />
+          <zeebe:input source="=&#34;QA Protocol&#34;" target="rootWorkflow" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0cosuvw</bpmn:incoming>


### PR DESCRIPTION
Adds a new variable `rootWorkflow` to the root workflows. The expectation is that this variable will be inherited to the processes called from the root workflow. This should make it easier in Operate to know which test came from where.

closes #125 