### PR TITLE
chore(workflows): extract testResult from testReport automatically

### DIFF
--- a/workflows/run-test-in-camunda-cloud.bpmn
+++ b/workflows/run-test-in-camunda-cloud.bpmn
@@ -13,7 +13,7 @@
       <bpmn:outgoing>test_skipped</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="test_failed" name="FAILED" sourceRef="check_test_result" targetRef="notify-engineers">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testResult = "FAILED"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "FAILED"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="notify-engineers" name="Notify Engineers">
       <bpmn:extensionElements>
@@ -36,7 +36,7 @@
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1emur0a" sourceRef="analysis-completed" targetRef="Gateway_0n2c5zt" />
     <bpmn:sequenceFlow id="test_passed" name="PASSED" sourceRef="check_test_result" targetRef="Gateway_0n2c5zt">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testResult = "PASSED"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "PASSED"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1e7iazb" sourceRef="Gateway_0n2c5zt" targetRef="destroy-zeebe-cluster-in-camunda-cloud" />
     <bpmn:serviceTask id="destroy-zeebe-cluster-in-camunda-cloud" name="Destroy Zeebe Cluster in Camunda Cloud">
@@ -75,7 +75,7 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_077bhk3" sourceRef="Activity_1hxzgjq" targetRef="check_test_result" />
     <bpmn:sequenceFlow id="test_skipped" name="SKIPPED" sourceRef="check_test_result" targetRef="Gateway_0n2c5zt">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testResult = "SKIPPED"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "SKIPPED"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:textAnnotation id="TextAnnotation_1g43008">
       <bpmn:text>messageName: Analysis Completed
@@ -90,9 +90,15 @@ correlationKey: cluserId</bpmn:text>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="run-test-in-camunda-cloud">
-      <bpmndi:BPMNShape id="TextAnnotation_1g43008_di" bpmnElement="TextAnnotation_1g43008">
-        <dc:Bounds x="1120" y="300" width="340" height="39" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1mgszoj_di" bpmnElement="test_skipped">
+        <di:waypoint x="790" y="145" />
+        <di:waypoint x="790" y="80" />
+        <di:waypoint x="1130" y="80" />
+        <di:waypoint x="1130" y="145" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="817" y="83" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_077bhk3_di" bpmnElement="Flow_077bhk3">
         <di:waypoint x="660" y="170" />
         <di:waypoint x="765" y="170" />
@@ -141,35 +147,20 @@ correlationKey: cluserId</bpmn:text>
         <di:waypoint x="188" y="170" />
         <di:waypoint x="240" y="170" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mgszoj_di" bpmnElement="test_skipped">
-        <di:waypoint x="790" y="145" />
-        <di:waypoint x="790" y="80" />
-        <di:waypoint x="1130" y="80" />
-        <di:waypoint x="1130" y="145" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="817" y="83" width="48" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
         <dc:Bounds x="152" y="152" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="159" y="195" width="25" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1hh2a2j_di" bpmnElement="prepare-zeebe-cluster-in-camunda-cloud">
-        <dc:Bounds x="240" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1a336zp_di" bpmnElement="Activity_17f0cpn">
-        <dc:Bounds x="410" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1hxzgjq_di" bpmnElement="Activity_1hxzgjq">
-        <dc:Bounds x="560" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0eoa092_di" bpmnElement="check_test_result" isMarkerVisible="true">
         <dc:Bounds x="765" y="145" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="713" y="133" width="53" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w6lwgr_di" bpmnElement="notify-engineers">
+        <dc:Bounds x="900" y="230" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_01a6edu_di" bpmnElement="analysis-completed">
         <dc:Bounds x="1042" y="252" width="36" height="36" />
@@ -186,8 +177,17 @@ correlationKey: cluserId</bpmn:text>
       <bpmndi:BPMNShape id="Event_1i1rnvk_di" bpmnElement="Event_1i1rnvk">
         <dc:Bounds x="1342" y="152" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1w6lwgr_di" bpmnElement="notify-engineers">
-        <dc:Bounds x="900" y="230" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1hh2a2j_di" bpmnElement="prepare-zeebe-cluster-in-camunda-cloud">
+        <dc:Bounds x="240" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1a336zp_di" bpmnElement="Activity_17f0cpn">
+        <dc:Bounds x="410" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hxzgjq_di" bpmnElement="Activity_1hxzgjq">
+        <dc:Bounds x="560" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1g43008_di" bpmnElement="TextAnnotation_1g43008">
+        <dc:Bounds x="1120" y="300" width="340" height="39" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_04pugfi_di" bpmnElement="Association_04pugfi">
         <di:waypoint x="1074" y="281" />


### PR DESCRIPTION
First step towards #122 

(Outdated) This adds an output mapping to the test process to automatically extract the test result from the test report.

Updated: This changes the flow conditions to use the `testResult` inside the `testReport` data, not the top level `testResult` variable

This makes the `testResult` variable obsolete, and then it can be removed from the test processes in later PRs.

