### PR TITLE
165 incorporate backend changes

### DIFF
--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/CloudAPIClientFactory.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/CloudAPIClientFactory.java
@@ -1,5 +1,6 @@
 package io.zeebe.clustertestbench.cloud;
 
+import io.zeebe.clustertestbench.cloud.filter.BadRequestResponseFilter;
 import io.zeebe.clustertestbench.cloud.oauth.OAuthInterceptor;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -19,7 +20,11 @@ public class CloudAPIClientFactory {
         OAuthInterceptor.forServiceAccountAuthorization(
             authenticationServerURL, audience, clientId, clientSecret);
 
-    Client client = ClientBuilder.newBuilder().register(oauthInterceptor).build();
+    Client client =
+        ClientBuilder.newBuilder()
+            .register(oauthInterceptor)
+            .register(BadRequestResponseFilter.class)
+            .build();
     WebTarget target = client.target(cloudApiUrl);
     ResteasyWebTarget rtarget = (ResteasyWebTarget) target;
     return rtarget.proxy(CloudAPIClient.class);

--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/filter/BadRequestResponseFilter.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/filter/BadRequestResponseFilter.java
@@ -1,0 +1,31 @@
+package io.zeebe.clustertestbench.cloud.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import org.apache.commons.io.IOUtils;
+
+public class BadRequestResponseFilter implements ClientResponseFilter {
+
+  @Override
+  public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext)
+      throws IOException {
+
+    if (responseContext.getStatus() == 400) {
+      String requestBody = new ObjectMapper().writeValueAsString(requestContext.getEntity());
+      String responseBody =
+          IOUtils.toString(responseContext.getEntityStream(), StandardCharsets.UTF_8);
+
+      throw new IOException(
+          "BAD REQUEST returned from URI: "
+              + requestContext.getUri()
+              + ", requestBody:"
+              + requestBody
+              + ", responseBody: "
+              + responseBody);
+    }
+  }
+}

--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/oauth/OAuthClientFactory.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/oauth/OAuthClientFactory.java
@@ -1,5 +1,6 @@
 package io.zeebe.clustertestbench.cloud.oauth;
 
+import io.zeebe.clustertestbench.cloud.filter.BadRequestResponseFilter;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -8,7 +9,8 @@ import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 public class OAuthClientFactory {
 
   public OAuthClient createOAuthClient(String authenticationURL) {
-    Client client = ClientBuilder.newClient();
+    Client client = ClientBuilder.newBuilder().register(BadRequestResponseFilter.class).build();
+
     WebTarget target = client.target(authenticationURL);
     ResteasyWebTarget rtarget = (ResteasyWebTarget) target;
     return rtarget.proxy(OAuthClient.class);

--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/request/CreateZeebeClientRequest.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/request/CreateZeebeClientRequest.java
@@ -1,7 +1,11 @@
 package io.zeebe.clustertestbench.cloud.request;
 
+import java.util.Collections;
+import java.util.List;
+
 public class CreateZeebeClientRequest {
 
+  private static final List<String> PERMISSIONS = Collections.singletonList("zeebe");
   private final String clientName;
 
   public CreateZeebeClientRequest(String clientName) {
@@ -10,6 +14,10 @@ public class CreateZeebeClientRequest {
 
   public String getClientName() {
     return clientName;
+  }
+
+  public List<String> getPermissions() {
+    return PERMISSIONS;
   }
 
   @Override

--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/response/ZeebeClientConnectiontInfo.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/response/ZeebeClientConnectiontInfo.java
@@ -14,9 +14,6 @@ public class ZeebeClientConnectiontInfo {
   @JsonAlias("ZEEBE_CLIENT_ID")
   private String zeebeClientId;
 
-  @JsonAlias("ZEEBE_CLIENT_SECRET")
-  private String zeebeClientSecret;
-
   @JsonAlias("ZEEBE_AUTHORIZATION_SERVER_URL")
   private String zeebeAuthorizationServerUrl;
 
@@ -44,14 +41,6 @@ public class ZeebeClientConnectiontInfo {
     this.zeebeClientId = zeebeClientId;
   }
 
-  public String getZeebeClientSecret() {
-    return zeebeClientSecret;
-  }
-
-  public void setZeebeClientSecret(String zeebeClientSecret) {
-    this.zeebeClientSecret = zeebeClientSecret;
-  }
-
   public String getZeebeAuthorizationServerUrl() {
     return zeebeAuthorizationServerUrl;
   }
@@ -72,8 +61,6 @@ public class ZeebeClientConnectiontInfo {
         + zeebeAddress
         + ", zeebeClientId="
         + zeebeClientId
-        + ", zeebeClientSecret="
-        + zeebeClientSecret
         + ", zeebeAuthorizationServerUrl="
         + zeebeAuthorizationServerUrl
         + "]";

--- a/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/response/ClientConnectiontInfoTest.java
+++ b/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/response/ClientConnectiontInfoTest.java
@@ -14,7 +14,7 @@ class ClientConnectiontInfoTest {
   void testDeserialization() throws JsonMappingException, JsonProcessingException {
     // given
     String jsonString =
-        "{\"ZEEBE_ADDRESS\": \"<zeebeAddress>\",\"ZEEBE_CLIENT_ID\": \"<zeebeClientId>\",\"ZEEBE_CLIENT_SECRET\": \"<zeebeClientSecret>\",\"ZEEBE_AUTHORIZATION_SERVER_URL\": \"<authorizationURL>\"}";
+        "{\"ZEEBE_ADDRESS\": \"<zeebeAddress>\",\"ZEEBE_CLIENT_ID\": \"<zeebeClientId>\",\"ZEEBE_AUTHORIZATION_SERVER_URL\": \"<authorizationURL>\"}";
 
     // when
     ZeebeClientConnectiontInfo actual =
@@ -23,7 +23,6 @@ class ClientConnectiontInfoTest {
     // then
     Assertions.assertThat(actual.getZeebeAddress()).isEqualTo("<zeebeAddress>");
     Assertions.assertThat(actual.getZeebeClientId()).isEqualTo("<zeebeClientId>");
-    Assertions.assertThat(actual.getZeebeClientSecret()).isEqualTo("<zeebeClientSecret>");
     Assertions.assertThat(actual.getZeebeAuthorizationServerUrl()).isEqualTo("<authorizationURL>");
   }
 }

--- a/core/src/main/java/io/zeebe/clustertestbench/handler/CreateClusterInCamundaCloudHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/CreateClusterInCamundaCloudHandler.java
@@ -57,7 +57,7 @@ public class CreateClusterInCamundaCloudHandler implements JobHandler {
 
       client
           .newCompleteCommand(job.getKey())
-          .variables(new Output(connectionInfo, name, clusterId))
+          .variables(new Output(createZeebeClientResponse, connectionInfo, name, clusterId))
           .send();
     } catch (Exception e) {
       cloudApiClient.deleteCluster(clusterId);
@@ -114,14 +114,18 @@ public class CreateClusterInCamundaCloudHandler implements JobHandler {
     private String clusterId;
     private String clusterName;
 
-    public Output(ZeebeClientConnectiontInfo connectionInfo, String clusterName, String clusterId) {
+    public Output(
+        CreateZeebeClientResponse createZeebeClientResponse,
+        ZeebeClientConnectiontInfo connectionInfo,
+        String clusterName,
+        String clusterId) {
       this.authenticationDetails =
           new CamundaCLoudAuthenticationDetailsImpl(
               connectionInfo.getZeebeAuthorizationServerUrl(),
               connectionInfo.getZeebeAudience(),
               connectionInfo.getZeebeAddress(),
-              connectionInfo.getZeebeClientId(),
-              connectionInfo.getZeebeClientSecret());
+              createZeebeClientResponse.getClientId(),
+              createZeebeClientResponse.getClientSecret());
       this.clusterName = clusterName;
       this.clusterId = clusterId;
     }

--- a/internal-cloud-client/src/main/java/io/zeebe/clustertestbench/internal/cloud/InternalCloudAPIClientFactory.java
+++ b/internal-cloud-client/src/main/java/io/zeebe/clustertestbench/internal/cloud/InternalCloudAPIClientFactory.java
@@ -1,5 +1,6 @@
 package io.zeebe.clustertestbench.internal.cloud;
 
+import io.zeebe.clustertestbench.cloud.filter.BadRequestResponseFilter;
 import io.zeebe.clustertestbench.cloud.oauth.OAuthInterceptor;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -21,7 +22,11 @@ public class InternalCloudAPIClientFactory {
         OAuthInterceptor.forUserAccountAuthorization(
             authenticationServerURL, audience, clientId, clientSecret, username, password);
 
-    Client client = ClientBuilder.newBuilder().register(oauthInterceptor).build();
+    Client client =
+        ClientBuilder.newBuilder()
+            .register(oauthInterceptor)
+            .register(BadRequestResponseFilter.class)
+            .build();
     WebTarget target = client.target(cloudApiUrl);
     ResteasyWebTarget rtarget = (ResteasyWebTarget) target;
     return rtarget.proxy(InternalCloudAPIClient.class);


### PR DESCRIPTION
closes #165 

The changes in the backend were:
* the request to create a client now has a permissions field
* the client secret is only returned as response to the create Zeebe client request
* the old secret returned in the response when asking for information on a client is set to an empty string

Changes in the testbench:
* add permissions to create zeebe client request
* use secret returned from create zeebe client request
* remove obsolete field `secret` from `ZeebeClientConnectionInfo`
* (not related to the bugfix, but necessary to debug what was going on) Add a response filter that throws an exception for _bad request_ responses and copies the request body and response body into the message of the exception