### PR TITLE
fix(chaos): use other version of date tool

### DIFF
--- a/core/chaos-workers/installDependencies.sh
+++ b/core/chaos-workers/installDependencies.sh
@@ -3,7 +3,7 @@ set -exuo
 
 # contains all dependencies which needs to be installed for the chaos docker image
 
-apk --no-cache add bash make curl openssl diffutils git jq
+apk --no-cache add bash make curl openssl diffutils git jq coreutils
 
 pip install chaostoolkit
 chaos --version


### PR DESCRIPTION
 Install coreutils package as dependency to have access to nanoseconds to generate correct timestamp (with milliseconds).

Output now before the last 3 numbers were missing
```
[zell chaos-workers/ ns:testbench]$ k exec -it chaos-worker-6c7484c474-jhrg8 --  date +%s%3N
1606397280716
```

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/167