### PR TITLE
chore(ci): change algo for generation names

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
@@ -13,8 +13,8 @@ import io.zeebe.clustertestbench.util.StringLookup;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class CreateGenerationInCamundaCloudHandler implements JobHandler {
 
@@ -30,7 +30,7 @@ public class CreateGenerationInCamundaCloudHandler implements JobHandler {
 
     final var zeebeImage = input.getZeebeImage();
 
-    final var generation = createGenerationName(zeebeImage);
+    final var generation = createGenerationName();
     final var templateGeneration = lookupTemplate(input.getGenerationTemplate());
     final var channelInfo = lookupChannel(input.getChannel());
 
@@ -82,8 +82,8 @@ public class CreateGenerationInCamundaCloudHandler implements JobHandler {
     internalApiClient.updateChannel(channelInfo.getUuid(), updateChannelRequest);
   }
 
-  protected static String createGenerationName(String zeebeImage) {
-    return "temp_" + zeebeImage + "_" + UUID.randomUUID().toString();
+  protected static String createGenerationName() {
+    return "temp_" + RandomStringUtils.randomAlphanumeric(10);
   }
 
   private GenerationInfo lookupTemplate(final String generationTemplate) {

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
@@ -125,7 +125,6 @@ class CreateGenerationInCamundaCloudHandlerTest {
       verify(spyInternalApiClient).createGeneration(argumentCapture.capture());
       final var request = argumentCapture.getValue();
 
-      assertThat(request.getName()).contains(ZEEBE_IMAGE);
       assertThat(request.getVersions())
           .containsOnly(
               entry(KEY_ZEEBE_IMAGE, ZEEBE_IMAGE),
@@ -145,8 +144,7 @@ class CreateGenerationInCamundaCloudHandlerTest {
       // when + then
       assertThatThrownBy(() -> sutLocal.handle(mockJobClient, mockActivatedJob))
           .isExactlyInstanceOf(RuntimeException.class)
-          .hasMessageContaining("Creation of generation unsuccessful")
-          .hasMessageContaining(ZEEBE_IMAGE);
+          .hasMessageContaining("Creation of generation unsuccessful");
     }
 
     @Test
@@ -264,18 +262,9 @@ class CreateGenerationInCamundaCloudHandlerTest {
   class GenerationNameTest {
 
     @Test
-    void shouldContainZeebeImage() {
-      // when
-      var actual = CreateGenerationInCamundaCloudHandler.createGenerationName(ZEEBE_IMAGE);
-
-      // then
-      assertThat(actual).contains(ZEEBE_IMAGE);
-    }
-
-    @Test
     void shouldStartWithTemp() {
       // when
-      var actual = CreateGenerationInCamundaCloudHandler.createGenerationName(ZEEBE_IMAGE);
+      var actual = CreateGenerationInCamundaCloudHandler.createGenerationName();
 
       // then
       assertThat(actual).startsWith("temp");
@@ -284,8 +273,8 @@ class CreateGenerationInCamundaCloudHandlerTest {
     @Test
     void shouldGenerateDifferentNamesWhenCalledMultipletimes() {
       // when
-      var actual1 = CreateGenerationInCamundaCloudHandler.createGenerationName(ZEEBE_IMAGE);
-      var actual2 = CreateGenerationInCamundaCloudHandler.createGenerationName(ZEEBE_IMAGE);
+      var actual1 = CreateGenerationInCamundaCloudHandler.createGenerationName();
+      var actual2 = CreateGenerationInCamundaCloudHandler.createGenerationName();
 
       // then
       assertThat(actual1).isNotEqualTo(actual2);


### PR DESCRIPTION
This changes the algorithm for names for generation that are created by the testbench.

Before:
`temp_[image name]_[UUID]` e.g. `temp_gcr.io/zeebe-io/zeebe:0.26.0-SNAPSHOT-3fbe61a3a766b126e146b098ba09509648ff2df7_94853a44-4229-4e5d-abb2-a19723b3956a`

Downsides:
* the name is massive. It looks terrible in the UI 
![image](https://user-images.githubusercontent.com/14032870/100382423-9ced9c00-301b-11eb-957f-82590751e93c.png)
* the UUID at the end is just so that we can have different generations for the same image (in case different tests are running. Each test is responsible for cleaning up its generation). However, this UUID is not the UUID of the generation (which will be generated after a name has been chosen). So this is confusing and overall a bad idea.
* the image name is also quite long as it contains registry, imagename, version, qualifier and full commit hash. Additionally, it's redundant information because a user could look it up in the UI which image was used. 

Change:
* use a random string instead
* it might be even better if the generation has a nonsensical name. This way no developer will mistakingly chose this generation when creating a cluster manually.

Now:
`temp_[10 alphanumeric digits]` e.g.(`temp_YacMC1F230`)