### PR TITLE
Use Slack incoming-webhooks to post messages

### DIFF
--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -48,7 +48,7 @@ kubectl create secret generic testbench-secrets --namespace="${namespace}" \
   --from-literal=cloudClientSecret="${CLOUD_CLIENT_SECRET}" \
   --from-literal=internalCloudClientSecret="${INTERNAL_CLOUD_CLIENT_SECRET}" \
   --from-literal=internalCloudPassword="${INTERNAL_CLOUD_PASSWORD}" \
-  --from-literal=slackToken="${SLACK_TOKEN}" \
+  --from-literal=slackWebhookUrl="${SLACK_WEBHOOK_URL}" \
   --from-literal=sheetsApiKeyfileContent="${SHEETS_API_KEYFILE_CONTENT}"
 
 # apply changes to testbench.yaml, if any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                         sourcePattern: '**/src/main/java',
                         runAlways: true
                     )
-                    zip zipFile: 'test-coverage-reports.zip', archive: true, glob: '**/target/site/jacoco/**'                    
+                    zip zipFile: 'test-coverage-reports.zip', archive: true, glob: '**/target/site/jacoco/**'
                 }
                 failure {
                     zip zipFile: 'test-reports.zip', archive: true, glob: '**/*/surefire-reports/**'
@@ -168,7 +168,7 @@ pipeline {
                                       [envVar: 'INTERNAL_CLOUD_CLIENT_SECRET', vaultKey: 'internalCloudClientSecret'],
                                       [envVar: 'INTERNAL_CLOUD_PASSWORD', vaultKey: 'internalCloudPassword'],
                                       [envVar: 'SHEETS_API_KEYFILE_CONTENT', vaultKey: 'sheetsApiKeyfileContent'],
-                                      [envVar: 'SLACK_TOKEN', vaultKey: 'slackToken'],
+                                      [envVar: 'SLACK_WEBHOOK_URL', vaultKey: 'slackWebhookUrl'],
                                   ]
                                  ],
                              ]

--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/BootstrapFromEnvVars.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/BootstrapFromEnvVars.java
@@ -78,8 +78,7 @@ public class BootstrapFromEnvVars {
           getEnvironmentvariable("SHEETS_API_KEYFILE_CONTENT", false);
       final String reportSheetID = getEnvironmentvariable("REPORT_SHEET_ID", false);
 
-      final String slackToken = getEnvironmentvariable("SLACK_TOKEN", false);
-      final String slackChannel = getEnvironmentvariable("SLACK_CHANNEL", false);
+      final String slackWebhookUrl = getEnvironmentvariable("SLACK_WEBHOOK_URL", false);
 
       new Launcher(
               contactPoint,
@@ -90,8 +89,7 @@ public class BootstrapFromEnvVars {
               internalCloudApiAuthenticationDetails,
               sheetsApiKeyfileContent,
               reportSheetID,
-              slackToken,
-              slackChannel)
+              slackWebhookUrl)
           .launch();
     } catch (final Exception e) {
       LOGGER.error(e.getMessage(), e);
@@ -105,7 +103,7 @@ public class BootstrapFromEnvVars {
     final String key = PREFIX + suffix;
 
     if (!optional && !envVars.containsKey(key)) {
-      throw new RuntimeException("Unable to find mandatory environment variable " + key);
+      throw new IllegalStateException("Unable to find mandatory environment variable " + key);
     }
 
     return envVars.get(key);

--- a/core/src/main/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandler.java
@@ -74,10 +74,10 @@ public class NotifyEngineersHandler implements JobHandler {
 
     input.getTestReport().getFailureMessages().stream() //
         .limit(TEST_FAILURE_SUMMARY_ITEMS) //
-        .forEachOrdered(msg -> resultBuilder.append(msg).append("\n"));
+        .forEachOrdered(msg -> resultBuilder.append("\n").append(msg));
 
     if (input.getTestReport().getFailureCount() > TEST_FAILURE_SUMMARY_ITEMS) {
-      resultBuilder.append("...\n");
+      resultBuilder.append("\n...\n");
     }
 
     return resultBuilder.toString();

--- a/docs/operator-handbook.md
+++ b/docs/operator-handbook.md
@@ -23,8 +23,8 @@ You need:
 - Google Sheet file to receive the test results
 - Google Sheet service account, token and permissions to write to that file
 - Kubernetes service account, token and permissions to interact with running clusters on Kubernetes level
-- Slack app and token to send notifications to a slack channel
 - Slack channel to receive notifications
+- Slack app and webhook URL to send notifications to a slack channel
 
 Setup and deployment:
 
@@ -80,18 +80,17 @@ Setup and deployment:
 | testbench.yaml | ZCTB_REPORT_SHEET_ID       | ID of the sheet you created (Press share, copy link; take the bit that looks like an ID) |
 | ENV_VARS       | SHEETS_API_KEYFILE_CONTENT | Complete content of downloaded key file                                                  |
 
-#### Slack App and Channel
+#### Slack App and Webhook
 
 1. Create a Slack application (https://api.slack.com/start/overview)
-1. Download token to authenticate the app
-1. Give it permissions to write to channels
+1. Create an incoming webhook for your app (https://api.slack.com/messaging/webhooks)
+1. Add a new webhook to your workspace for the desired channel (you may need approval from your workspace admin)
 1. Invite your app to the channel it should publish to
 1. Fill deployment descriptors as follows:
 
 | File           | Field              | Content                         |
 | -------------- | ------------------ | ------------------------------- |
-| testbench.yaml | ZCTB_SLACK_CHANNEL | The slack channel to publish to |
-| ENV_VARS       | SLACK_TOKEN        | The token for your app          |
+| ENV_VARS       | SLACK_WEBHOOK_URL  | The webhook URL for your app    |
 
 #### Chaos Experiments
 

--- a/testbench-dev.yaml
+++ b/testbench-dev.yaml
@@ -73,13 +73,11 @@ spec:
                   key: sheetsApiKeyfileContent
             - name: ZCTB_REPORT_SHEET_ID
               value: "1l3ofIIHKHWTjRs1IpZYl1ULMfqkyGpL7JRarkR0of94"
-            - name: ZCTB_SLACK_TOKEN
+            - name: ZCTB_SLACK_WEBHOOK_URL
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets
-                  key: slackToken
-            - name: ZCTB_SLACK_CHANNEL
-              value: "#slack-bot-dev"
+                  key: slackWebhookUrl
           resources:
             limits:
               cpu: 4

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -73,13 +73,11 @@ spec:
                   key: sheetsApiKeyfileContent
             - name: ZCTB_REPORT_SHEET_ID
               value: "1ruQ1zmOj_Wed-WqDOU69wF79hsBHce5CvUAF5UEbC20"
-            - name: ZCTB_SLACK_TOKEN
+            - name: ZCTB_SLACK_WEBHOOK_URL
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets
-                  key: slackToken
-            - name: ZCTB_SLACK_CHANNEL
-              value: "#testbench"
+                  key: slackWebhookUrl
           resources:
             limits:
               cpu: 4


### PR DESCRIPTION
**Description**

This PR removes the real-time-messaging Slack integration and replaces it with a simple incoming-webhook usage. See the original issue as to why.

The self test is replaced with a simple request sending an empty payload which should return a specific error. This is somewhat brittle, and welcome to be challenged (not sufficient to check the error code as using a weird URL will still return a 400, just a different error).

Vault has been updated with a new `slackWebhookUrl`, and the docs have also been updated (partially - it seems other parts also need to be updated but were outside of this scope).

**Related issues**

closes #212 