### PR TITLE
chore(core): update zbctl

### DIFF
--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-alpine
 
 ARG TOKEN
-ENV ZEEBE_VERSION=0.24.3 \
+ENV ZEEBE_VERSION=0.26.0 \
     CHAOS_HOME=/home/chaos \
     CONTEXT=gke_camunda-cloud-240911_europe-west1-d_ultrachaos
 


### PR DESCRIPTION
We had again the issue that the cloud token was not updated/renewed after the TTL expired. I hope that a newer version of zbctl fixes that. Otherwise I will reopen again some issues in zeebe.