### PR TITLE
github(dependabot): Configure Dependabot to run also for stable branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,10 @@ updates:
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    target-branch: "develop"
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "stable/0.26"


### PR DESCRIPTION
Changes dependabot conifguration:
* will now run daily instead of weekly
* will also run for `stable/0.26`
Fixes: #261 