### PR TITLE
Deploy multi version worker

### DIFF
--- a/core/chaos-workers/.gitignore
+++ b/core/chaos-workers/.gitignore
@@ -1,4 +1,5 @@
 createAndRunImage.sh
+testAction.sh
 testbenchDebug.sh
 output-*.log
 debugWorker.sh

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -1,0 +1,78 @@
+package io.zeebe.chaos;
+
+import io.zeebe.client.ZeebeClient
+import io.zeebe.client.api.response.ActivatedJob
+import io.zeebe.client.api.worker.JobClient
+import io.zeebe.client.api.worker.JobHandler
+import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder
+import io.zeebe.model.bpmn.Bpmn
+import io.zeebe.model.bpmn.BpmnModelInstance
+import org.camunda.bpm.model.xml.ModelInstance
+
+class DeployMultipleVersionsHandler : JobHandler {
+
+    private val PROCESS_ID = "multiVersion"
+    private val MODEL_V1 = Bpmn.createExecutableProcess(PROCESS_ID).name("v1").startEvent().endEvent().done()
+    private val MODEL_V2 = Bpmn.createExecutableProcess(PROCESS_ID).name("v2").startEvent().endEvent().done()
+    private val LOG = org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.DeployMultipleVersionsHandler")
+
+    companion object {
+        const val JOB_TYPE = "deploy-different-versions.sh"
+    }
+
+    override fun handle(client: JobClient, job: ActivatedJob) {
+        LOG.info("Handle job {}", JOB_TYPE)
+
+        val authenticationDetails = job.variablesAsMap["authenticationDetails"]!! as Map<String, Any>
+        createClient(authenticationDetails).use {
+            LOG.info("Connected to {}, start deploying multiple versions...", it.configuration.gatewayAddress)
+
+            var version = -1
+            do {
+                deployModel(it, MODEL_V1, "modelV1.bpmn")
+                version = deployModel(it, MODEL_V2, "modelV2.bpmn")
+            } while (version < 10)
+
+            LOG.info("Deployed 10 different versions of process {}. Complete {}", PROCESS_ID, JOB_TYPE)
+        }
+
+        client.newCompleteCommand(job.key).send()
+    }
+
+    private fun deployModel(client: ZeebeClient, model: BpmnModelInstance, name: String) : Int{
+        var version = -1
+        do {
+            try {
+                val deploymentEvent = client.newDeployCommand().addWorkflowModel(model, name).send().join()
+                version = deploymentEvent.workflows[0].version
+            } catch (e: Exception) {
+                // try again
+                LOG.debug("Failed to deploy {}, try again.", name, e)
+                Thread.sleep(100)
+            }
+        } while (version == -1)
+        return version
+    }
+
+
+    private fun createClient(authenticationDetails: Map<String, Any>): ZeebeClient {
+        val clientId = authenticationDetails["clientId"]!!.toString()
+        val clientSecret = authenticationDetails["clientSecret"]!!.toString()
+        val authorizationURL = authenticationDetails["authorizationURL"]!!.toString()
+        val audience = authenticationDetails["audience"]!!.toString()
+        val contactPoint = authenticationDetails["contactPoint"]!!.toString()
+
+        val credentialsProvider = OAuthCredentialsProviderBuilder()
+            .audience(audience)
+            .authorizationServerUrl(authorizationURL)
+            .clientId(clientId)
+            .clientSecret(clientSecret)
+            .credentialsCachePath("/tmp/" + JOB_TYPE + ".cred")
+            .build()
+
+        return ZeebeClient.newClientBuilder()
+            .credentialsProvider(credentialsProvider)
+            .gatewayAddress(contactPoint)
+            .build()
+    }
+}

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -47,11 +47,13 @@ fun main() {
     scriptPath.listFiles { file -> file.extension == SHELL_EXTENSION }!!
         .map { it.name }
         .filterNot { it.contains("utils") }
+        .filterNot { it.equals(DeployMultipleVersionsHandler.JOB_TYPE) }
         .forEach { script ->
             LOG.info("Start worker with type `$script`")
             zeebeClient.newWorker().jobType(script).handler(::handler).open()
         }
 
+    zeebeClient.newWorker().jobType(DeployMultipleVersionsHandler.JOB_TYPE).handler(DeployMultipleVersionsHandler()).open()
     zeebeClient.newWorker().jobType("readExperiments").handler(::readExperiments).open()
 
     // keep workers running

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -10,6 +10,11 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+private const val ENV_TESTBENCH_ADDRESS = "TESTBENCH_ADDRESS"
+private const val ENV_TESTBENCH_CLIENT_ID = "TESTBENCH_CLIENT_ID"
+private const val ENV_TESTBENCH_CLIENT_SECRET = "TESTBENCH_CLIENT_SECRET"
+private const val ENV_TESTBENCH_AUTHORIZATION_SERVER_URL = "TESTBENCH_AUTHORIZATION_SERVER_URL"
+
 private const val ROOT_PATH = "zeebe-chaos/chaos-experiments"
 private const val SHELL_EXTENSION = "sh"
 private const val EXPERIMENT_FILE_NAME = "experiment.json"
@@ -18,15 +23,15 @@ private val LOG = org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.ChaosWorker"
 
 private fun createClient(): ZeebeClient {
     val audience = OAuthCredentialsProviderBuilder()
-        .audience(System.getenv("ZEEBE_ADDRESS").removeSuffix(":443"))
-        .authorizationServerUrl(System.getenv("ZEEBE_AUTHORIZATION_SERVER_URL"))
-        .clientId(System.getenv("ZEEBE_CLIENT_ID"))
-        .clientSecret(System.getenv("ZEEBE_CLIENT_SECRET"))
+        .audience(System.getenv(ENV_TESTBENCH_ADDRESS).removeSuffix(":443"))
+        .authorizationServerUrl(System.getenv(ENV_TESTBENCH_AUTHORIZATION_SERVER_URL))
+        .clientId(System.getenv(ENV_TESTBENCH_CLIENT_ID))
+        .clientSecret(System.getenv(ENV_TESTBENCH_CLIENT_SECRET))
         .build()
 
     return ZeebeClient.newClientBuilder()
         .credentialsProvider(audience)
-        .gatewayAddress(System.getenv("ZEEBE_ADDRESS"))
+        .gatewayAddress(System.getenv(ENV_TESTBENCH_ADDRESS))
         .numJobWorkerExecutionThreads(4)
         .build()
 }

--- a/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
+++ b/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
@@ -9,6 +9,7 @@ xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://raw.githu
 </Appenders>
 <Loggers>
   <Logger name="io.zeebe.bpmnspec" level="trace"/>
+  <Logger name="io.zeebe.chaos" level="debug"/>
   <Logger name="io.zeebe" level="info"/>
   <Logger name="io.zeebe.client.job.poller" level="error"/>
   <Root level="error">

--- a/core/chaos-workers/deployment/chaosWorker-dev.yaml
+++ b/core/chaos-workers/deployment/chaosWorker-dev.yaml
@@ -23,16 +23,16 @@ spec:
           image: gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:dev
           imagePullPolicy: Always
           env:
-            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+            - name: TESTBENCH_AUTHORIZATION_SERVER_URL
               value: "https://login.cloud.dev.ultrawombat.com/oauth/token"
-            - name: ZEEBE_CLIENT_ID
+            - name: TESTBENCH_CLIENT_ID
               value: "cOf2ryfrDoCaHqXFwrQm7y7n9yEP4Imp"
-            - name: ZEEBE_CLIENT_SECRET
+            - name: TESTBENCH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets
                   key: clientSecret
-            - name: ZEEBE_ADDRESS
+            - name: TESTBENCH_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets

--- a/core/chaos-workers/deployment/chaosWorker.yaml
+++ b/core/chaos-workers/deployment/chaosWorker.yaml
@@ -23,16 +23,16 @@ spec:
           image: gcr.io/zeebe-io/zeebe-cluster-testbench-chaos:latest
           imagePullPolicy: Always
           env:
-            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+            - name: TESTBENCH_AUTHORIZATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
-            - name: ZEEBE_CLIENT_ID
+            - name: TESTBENCH_CLIENT_ID
               value: "W5a4JUc3I1NIetNnodo3YTvdsRIFb12w"
-            - name: ZEEBE_CLIENT_SECRET
+            - name: TESTBENCH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets
                   key: clientSecret
-            - name: ZEEBE_ADDRESS
+            - name: TESTBENCH_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: testbench-secrets


### PR DESCRIPTION
I wanted to replace the [deploy different version](https://github.com/zeebe-io/zeebe-chaos/blob/master/chaos-experiments/scripts/deploy-different-versions.sh) scripts with a kotlin worker, in general it worked and I like the resultat but I had problem to run it.

I get always:

```
18:31:57.681 [grpc-default-executor-4] ERROR Java Client: io.zeebe.client.impl.oauth.OAuthCredentialsProvider - Failed while fetching credentials: 
java.io.IOException: Failed while requesting access token with status code 429 and message Too Many Requests.
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.fetchCredentials(OAuthCredentialsProvider.java:184) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.refreshCredentials(OAuthCredentialsProvider.java:133) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.shouldRetryRequest(OAuthCredentialsProvider.java:101) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.RetriableClientFutureImpl.onError(RetriableClientFutureImpl.java:48) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:617) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:803) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:782) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
18:31:59.998 [grpc-default-executor-4] ERROR Java Client: io.zeebe.client.impl.oauth.OAuthCredentialsProvider - Failed while fetching credentials: 
java.io.IOException: Failed while requesting access token with status code 429 and message Too Many Requests.
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.fetchCredentials(OAuthCredentialsProvider.java:184) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.refreshCredentials(OAuthCredentialsProvider.java:133) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.shouldRetryRequest(OAuthCredentialsProvider.java:101) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.RetriableClientFutureImpl.onError(RetriableClientFutureImpl.java:48) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:617) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:803) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:782) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
18:32:00.445 [grpc-default-executor-4] ERROR Java Client: io.zeebe.client.impl.oauth.OAuthCredentialsProvider - Failed while fetching credentials: 
java.io.IOException: Failed while requesting access token with status code 429 and message Too Many Requests.
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.fetchCredentials(OAuthCredentialsProvider.java:184) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.refreshCredentials(OAuthCredentialsProvider.java:133) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.oauth.OAuthCredentialsProvider.shouldRetryRequest(OAuthCredentialsProvider.java:101) ~[chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.zeebe.client.impl.RetriableClientFutureImpl.onError(RetriableClientFutureImpl.java:48) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:478) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:617) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:803) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:782) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123) [chaosWorker.jar:2.0.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
```

It seems to be a problem with creating multiple clients in one application?

Maybe @pihme @saig0 has an idea?