### PR TITLE
Use 0.26.1 tag in Chaos Worker

### DIFF
--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -1,8 +1,7 @@
 FROM openjdk:11-jre as pre
 
 ARG TOKEN
-ENV ZEEBE_VERSION=0.26.0 \
-    CHAOS_HOME=/home/chaos \
+ENV CHAOS_HOME=/home/chaos \
     CONTEXT=gke_camunda-cloud-240911_europe-west1-d_ultrachaos
 
 WORKDIR ${CHAOS_HOME}
@@ -11,11 +10,13 @@ ENV PATH "${CHAOS_HOME}:${PATH}"
 
 # install dependencies
 RUN ${CHAOS_HOME}/installDependencies.sh
-RUN git clone https://github.com/zeebe-io/zeebe-chaos.git
+RUN git clone https://github.com/zeebe-io/zeebe-chaos.git \
+    && cd zeebe-chaos/ \
+    && git checkout 0.26.1
 
 # current user is root so we need to copy it to root
 # probably we want to create a different user
-RUN mkdir -p .kube
+RUN mkdir -p /root/.kube
 COPY kubeconfig /root/.kube/config
 RUN kubectl config set-credentials ${CONTEXT}-zeebe-chaos-token-user --token ${TOKEN}
 RUN kubectl config set-context ${CONTEXT} --user ${CONTEXT}-zeebe-chaos-token-user

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -6,7 +6,6 @@ import io.zeebe.client.api.worker.JobClient
 import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder
 import java.io.File
 import java.nio.file.Files
-import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -33,7 +32,7 @@ private fun createClient(): ZeebeClient {
 
 fun main() {
     // given
-    updateRepo() // get latest zeebe-chaos repo changes
+    showGitStatus()
     val zeebeClient = createClient()
 
     LOG.info("Connected to ${zeebeClient.configuration.gatewayAddress}")
@@ -147,10 +146,10 @@ private fun createCommandList(
 }
 
 /**
- * Get latest state of the zeebe-chaos repository, so we can run the latest experiments.
+ * Get current status information of git zeebe-chaos repo.
  */
-fun updateRepo() {
-    runCommands(File(ROOT_PATH), "git", "pull", "origin", "master")
+fun showGitStatus() {
+    runCommands(File(ROOT_PATH), "git", "status")
 }
 
 /**


### PR DESCRIPTION
 In order to change the zeebe-chaos experiments, to make them 1.x compatible, we need to use in the chaos worker the old experiments (tagged with 0.26.1). In the Testbench 1.x we can then use the newer experiments which are migrated and on the older Testbench the 0.26.1 version.