### PR TITLE
fix(script): correct wait-for-result job key parsing

### DIFF
--- a/scripts/wait-for-result.sh
+++ b/scripts/wait-for-result.sh
@@ -21,7 +21,7 @@ while [ $waiting -eq 1 ]; do
 
     zbctl activate jobs "$businessKey" --insecure > activationresponse.txt 2>error.txt
 
-    key=$(jq -r '.key' < activationresponse.txt)
+    key=$(jq -r '.jobs[0].key' < activationresponse.txt)
 
     if [ -z "$key" ]; then
         echo "Still waiting"
@@ -36,11 +36,11 @@ echo "Job Completed"
 zbctl complete job "$key" --insecure
 
 # example: extract aggrgated test result
-key=$(jq -r '.key' < activationresponse.txt)
+key=$(jq -r '.jobs[0].key' < activationresponse.txt)
 
 echo "Job key is: $key"
 
-variables=$(jq -r '.variables' < activationresponse.txt)
+variables=$(jq -r '.jobs[0].variables' < activationresponse.txt)
 
 echo "Job variables are: $variables"
 


### PR DESCRIPTION
Zbctl nowaways returns jobs differently. It used to be an array of jobs,
now it is a json object with a `jobs` property that contains the array
of jobs, i.e. instead of `[]`, it's now `{"jobs":[]}`.

closes #194 