### PR TITLE
fix(zeebe): replace deprecated brokerContactPoint

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
@@ -91,7 +91,7 @@ public class Launcher {
     try (final ZeebeClient client =
         ZeebeClient.newClientBuilder()
             .numJobWorkerExecutionThreads(50)
-            .brokerContactPoint(testOrchestrationContactPoint)
+            .gatewayAddress(testOrchestrationContactPoint)
             .credentialsProvider(cred)
             .build(); ) {
 
@@ -139,7 +139,7 @@ public class Launcher {
     try (final ZeebeClient client =
         ZeebeClient.newClientBuilder()
             .numJobWorkerExecutionThreads(50)
-            .brokerContactPoint(testOrchestrationContactPoint)
+            .gatewayAddress(testOrchestrationContactPoint)
             .credentialsProvider(cred)
             .build(); ) {
       client.newTopologyRequest().send().join();

--- a/core/src/main/java/io/zeebe/clustertestbench/handler/WarmUpClusterHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/WarmUpClusterHandler.java
@@ -34,7 +34,7 @@ public class WarmUpClusterHandler implements JobHandler {
 
     try (final ZeebeClient zeebeClient =
         ZeebeClient.newClientBuilder()
-            .brokerContactPoint(authenticationDetails.getContactPoint())
+            .gatewayAddress(authenticationDetails.getContactPoint())
             .credentialsProvider(cred)
             .build()) {
 

--- a/testdriver/sequential/src/main/java/io/zeebe/clustertestbench/testdriver/sequential/SequentialTestDriver.java
+++ b/testdriver/sequential/src/main/java/io/zeebe/clustertestbench/testdriver/sequential/SequentialTestDriver.java
@@ -58,7 +58,7 @@ public class SequentialTestDriver implements TestDriver {
 
     client =
         ZeebeClient.newClientBuilder()
-            .brokerContactPoint(authenticationDetails.getContactPoint())
+            .gatewayAddress(authenticationDetails.getContactPoint())
             .credentialsProvider(cred)
             .build();
 


### PR DESCRIPTION
This will make #308 possible. `brokerContactPoint` was already deprecated for some time, but is removed in `1.0.0-alpha7`. It should be replaced by `gatewayAddress`.