### PR TITLE
Switch to 1.0.0-rc1 cluster

### DIFF
--- a/core/chaos-workers/deployment/chaosWorker-prod.yaml
+++ b/core/chaos-workers/deployment/chaosWorker-prod.yaml
@@ -26,7 +26,7 @@ spec:
             - name: TESTBENCH_AUTHORIZATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
             - name: TESTBENCH_CLIENT_ID
-              value: "ELL8eP0qDkl6dxXVps0t51x2VkCkWf~p"
+              value: "6WIMz9KT7076gBWmfV7QJK0zGNotmF04"
             - name: TESTBENCH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/testbench-prod.yaml
+++ b/testbench-prod.yaml
@@ -22,7 +22,7 @@ spec:
             - name: ZCTB_AUTHENTICATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
             - name: ZCTB_CLIENT_ID
-              value: "ELL8eP0qDkl6dxXVps0t51x2VkCkWf~p"
+              value: "6WIMz9KT7076gBWmfV7QJK0zGNotmF04"
             - name: ZCTB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The switch is made by switching the client-id and by changing the values
in vault.