### PR TITLE
fix(testdriver): make sequential process executable

### DIFF
--- a/testdriver/sequential/src/main/java/io/zeebe/clustertestbench/testdriver/sequential/SequentialTestDriver.java
+++ b/testdriver/sequential/src/main/java/io/zeebe/clustertestbench/testdriver/sequential/SequentialTestDriver.java
@@ -67,7 +67,7 @@ public class SequentialTestDriver implements TestDriver {
   }
 
   private void createAndDeploySequentialProcess() {
-    AbstractFlowNodeBuilder<?, ?> builder = Bpmn.createProcess(PROCESS_ID).startEvent();
+    AbstractFlowNodeBuilder<?, ?> builder = Bpmn.createExecutableProcess(PROCESS_ID).startEvent();
     for (int i = 0; i < testParameters.getSteps(); i++) {
       builder =
           builder


### PR DESCRIPTION
When replacing the external dependency to zeebe-workflow-generator, it
seems the wrong method was called to create the sequential test process.