### PR TITLE
Add on-comment trigger to backport action workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,14 +1,18 @@
-name: Backport labeled PRs after merge
+name: Backport labeled merged pull requests
 on:
   pull_request:
     types: [ closed ]
+  issue_comment:
+    types: [ created ]
 jobs:
   build:
     name: Create backport PRs
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/backport')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
+          # required to find all branches
           fetch-depth: 0
       - name: Create backport PRs
         uses: zeebe-io/backport-action@master


### PR DESCRIPTION
Adds a workflow configuration to trigger the backport action
when a user writes a `/backport` comment on a pull request.
The bot itself restricts that only merged pull requests can be
backported.

This allows to backport pull requests that have already been merged.
Just add the backport labels to the merged PR and write `/backport`.

> WARNING! The bot will try to backport to the branches of all backport labels.
> Previously created backport pull requests are not taken into account.
> New pull requests will be created for each label.
