### PR TITLE
ci(github): fix backport conditions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,12 +9,12 @@ jobs:
     name: Create backport PRs
     if: >
       ${{
-        github.event_name == 'pull_request' ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          contains(github.event.comment.body, '/backport')
-        )
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/backport')
+      )
       }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The backport was running unconditionally after #341. It might be that the expression syntax is the cause of this.