### PR TITLE
Add more details to failure msgs

### DIFF
--- a/processes/actionRunner.bpmn
+++ b/processes/actionRunner.bpmn
@@ -5,6 +5,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=true" target="successfulRun" />
+          <zeebe:output source="=if (is defined(action.provider.timeout)) then &#34;PT&#34; + string(action.provider.timeout) + &#34;S&#34; else &#34;PT1H&#34;" target="timeout" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_13awudk</bpmn:outgoing>
@@ -50,13 +51,13 @@
     <bpmn:boundaryEvent id="Event_0owkcly" name="Timeout" attachedToRef="Activity_1xzr6io">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=append(testReport.failureMessages, (&#34; Action with name: &#39;&#34; + action.name + &#34; timed out.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Action with name: &#39;&#34; + action.name + &#34;&#39; timed out after &#34; + timeout + &#34;.&#34;))" target="testReport.failureMessages" />
           <zeebe:output source="= false" target="successfulRun" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_0yhcmxv</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_1eo7nl1">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=if (is defined(action.provider.timeout)) then duration("PT" + string(action.provider.timeout) + "S") else duration("PT1H")</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=duration(timeout)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0yhcmxv" sourceRef="Event_0owkcly" targetRef="Event_1quq7fu" />
@@ -135,14 +136,14 @@
       <bpmndi:BPMNShape id="Event_0zo9lot_di" bpmnElement="Event_0zo9lot">
         <dc:Bounds x="522" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1pm343k_di" bpmnElement="TextAnnotation_1pm343k">
-        <dc:Bounds x="180" y="270" width="100" height="68" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0s989l1_di" bpmnElement="Event_1quq7fu">
         <dc:Bounds x="722" y="292" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="710" y="335" width="60" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1pm343k_di" bpmnElement="TextAnnotation_1pm343k">
+        <dc:Bounds x="180" y="270" width="100" height="68" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1bnzi0o_di" bpmnElement="Event_0owkcly">
         <dc:Bounds x="302" y="172" width="36" height="36" />

--- a/processes/chaosExperiment.bpmn
+++ b/processes/chaosExperiment.bpmn
@@ -129,7 +129,7 @@
     <bpmn:boundaryEvent id="Event_06uq3eg" name="Chaos Experiment failed" attachedToRef="Activity_11tzpu9">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=append(testReport.failureMessages, (&#34; Chaos experiment &#34; + experiment.title + &#34; failed.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Chaos experiment &#39;&#34; + experiment.title + &#34;&#39; failed.&#34;))" target="testReport.failureMessages" />
           <zeebe:output source="= false" target="successfulExperiment" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -199,62 +199,41 @@
         <di:waypoint x="1030" y="570" />
         <di:waypoint x="1355" y="570" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="162" y="252" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="152" y="295" width="56" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0cqap4f_di" bpmnElement="Event_0cqap4f">
-        <dc:Bounds x="1862" y="262" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1852" y="305" width="56" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1ty24uf_di" bpmnElement="Gateway_1ty24uf" isMarkerVisible="true">
-        <dc:Bounds x="1355" y="545" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_03kptlx_di" bpmnElement="Event_0i9wjj1">
-        <dc:Bounds x="1862" y="552" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1838" y="595" width="85" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1cqlnii_di" bpmnElement="Activity_11tzpu9" isExpanded="true">
         <dc:Bounds x="240" y="120" width="1590" height="340" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0sqgo4r_di" bpmnElement="Flow_0sqgo4r">
-        <di:waypoint x="298" y="280" />
-        <di:waypoint x="330" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0uiwbuz_di" bpmnElement="Flow_0uiwbuz">
-        <di:waypoint x="780" y="280" />
-        <di:waypoint x="820" y="280" />
+      <bpmndi:BPMNEdge id="Flow_1itk0ag_di" bpmnElement="Flow_1itk0ag">
+        <di:waypoint x="1750" y="280" />
+        <di:waypoint x="1772" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1urawfk_di" bpmnElement="Flow_1urawfk">
         <di:waypoint x="1270" y="280" />
         <di:waypoint x="1300" y="280" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1itk0ag_di" bpmnElement="Flow_1itk0ag">
-        <di:waypoint x="1750" y="280" />
-        <di:waypoint x="1772" y="280" />
+      <bpmndi:BPMNEdge id="Flow_0uiwbuz_di" bpmnElement="Flow_0uiwbuz">
+        <di:waypoint x="780" y="280" />
+        <di:waypoint x="820" y="280" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1u9f9sk_di" bpmnElement="Event_1u9f9sk">
-        <dc:Bounds x="262" y="262" width="36" height="36" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0sqgo4r_di" bpmnElement="Flow_0sqgo4r">
+        <di:waypoint x="298" y="280" />
+        <di:waypoint x="330" y="280" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0ulf3ce_di" bpmnElement="Event_0ulf3ce">
         <dc:Bounds x="1772" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u9f9sk_di" bpmnElement="Event_1u9f9sk">
+        <dc:Bounds x="262" y="262" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1cxs1dd_di" bpmnElement="Activity_1cxs1dd" isExpanded="true">
         <dc:Bounds x="330" y="180" width="450" height="230" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1or504g_di" bpmnElement="Flow_1or504g">
-        <di:waypoint x="386" y="280" />
-        <di:waypoint x="440" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_104lujp_di" bpmnElement="Flow_104lujp">
-        <di:waypoint x="540" y="280" />
-        <di:waypoint x="595" y="280" />
+      <bpmndi:BPMNEdge id="Flow_0vh336v_di" bpmnElement="Flow_0vh336v">
+        <di:waypoint x="620" y="305" />
+        <di:waypoint x="620" y="360" />
+        <di:waypoint x="712" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="628" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0erwgmy_di" bpmnElement="Flow_0erwgmy">
         <di:waypoint x="645" y="280" />
@@ -263,13 +242,13 @@
           <dc:Bounds x="660" y="263" width="19" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vh336v_di" bpmnElement="Flow_0vh336v">
-        <di:waypoint x="620" y="305" />
-        <di:waypoint x="620" y="360" />
-        <di:waypoint x="712" y="360" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="628" y="330" width="15" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_104lujp_di" bpmnElement="Flow_104lujp">
+        <di:waypoint x="540" y="280" />
+        <di:waypoint x="595" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1or504g_di" bpmnElement="Flow_1or504g">
+        <di:waypoint x="386" y="280" />
+        <di:waypoint x="440" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1acs4yl_di" bpmnElement="Event_1acs4yl">
         <dc:Bounds x="350" y="262" width="36" height="36" />
@@ -292,13 +271,13 @@
       <bpmndi:BPMNShape id="Activity_0nqerfm_di" bpmnElement="Activity_0nqerfm" isExpanded="true">
         <dc:Bounds x="820" y="180" width="450" height="230" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_10u4oy7_di" bpmnElement="Flow_10u4oy7">
-        <di:waypoint x="876" y="280" />
-        <di:waypoint x="930" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fgc04f_di" bpmnElement="Flow_0fgc04f">
-        <di:waypoint x="1030" y="280" />
-        <di:waypoint x="1085" y="280" />
+      <bpmndi:BPMNEdge id="Flow_0yi4wz0_di" bpmnElement="Flow_0yi4wz0">
+        <di:waypoint x="1110" y="305" />
+        <di:waypoint x="1110" y="360" />
+        <di:waypoint x="1202" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1118" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1d9u51w_di" bpmnElement="Flow_1d9u51w">
         <di:waypoint x="1135" y="280" />
@@ -307,13 +286,13 @@
           <dc:Bounds x="1150" y="263" width="19" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0yi4wz0_di" bpmnElement="Flow_0yi4wz0">
-        <di:waypoint x="1110" y="305" />
-        <di:waypoint x="1110" y="360" />
-        <di:waypoint x="1202" y="360" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1118" y="330" width="15" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_0fgc04f_di" bpmnElement="Flow_0fgc04f">
+        <di:waypoint x="1030" y="280" />
+        <di:waypoint x="1085" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10u4oy7_di" bpmnElement="Flow_10u4oy7">
+        <di:waypoint x="876" y="280" />
+        <di:waypoint x="930" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_00iakpz_di" bpmnElement="Event_00iakpz">
         <dc:Bounds x="840" y="262" width="36" height="36" />
@@ -336,13 +315,13 @@
       <bpmndi:BPMNShape id="Activity_1elridj_di" bpmnElement="Activity_1elridj" isExpanded="true">
         <dc:Bounds x="1300" y="180" width="450" height="230" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0m1gisv_di" bpmnElement="Flow_0m1gisv">
-        <di:waypoint x="1356" y="280" />
-        <di:waypoint x="1410" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1br1dnv_di" bpmnElement="Flow_1br1dnv">
-        <di:waypoint x="1510" y="280" />
-        <di:waypoint x="1565" y="280" />
+      <bpmndi:BPMNEdge id="Flow_0l3cz4w_di" bpmnElement="Flow_0l3cz4w">
+        <di:waypoint x="1590" y="305" />
+        <di:waypoint x="1590" y="360" />
+        <di:waypoint x="1682" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1598" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_05mvpkj_di" bpmnElement="Flow_05mvpkj">
         <di:waypoint x="1615" y="280" />
@@ -351,13 +330,13 @@
           <dc:Bounds x="1630" y="263" width="19" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0l3cz4w_di" bpmnElement="Flow_0l3cz4w">
-        <di:waypoint x="1590" y="305" />
-        <di:waypoint x="1590" y="360" />
-        <di:waypoint x="1682" y="360" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1598" y="330" width="15" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_1br1dnv_di" bpmnElement="Flow_1br1dnv">
+        <di:waypoint x="1510" y="280" />
+        <di:waypoint x="1565" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1gisv_di" bpmnElement="Flow_0m1gisv">
+        <di:waypoint x="1356" y="280" />
+        <di:waypoint x="1410" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0j24lps_di" bpmnElement="Event_0j24lps">
         <dc:Bounds x="1320" y="262" width="36" height="36" />
@@ -376,6 +355,27 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_165b83s_di" bpmnElement="Event_165b83s">
         <dc:Bounds x="1682" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ty24uf_di" bpmnElement="Gateway_1ty24uf" isMarkerVisible="true">
+        <dc:Bounds x="1355" y="545" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cqap4f_di" bpmnElement="Event_0cqap4f">
+        <dc:Bounds x="1862" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1852" y="305" width="56" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="162" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="152" y="295" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03kptlx_di" bpmnElement="Event_0i9wjj1">
+        <dc:Bounds x="1862" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1838" y="595" width="85" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_07yabv0_di" bpmnElement="Event_036qm76">
         <dc:Bounds x="1362" y="442" width="36" height="36" />

--- a/processes/chaosToolkit.bpmn
+++ b/processes/chaosToolkit.bpmn
@@ -71,7 +71,7 @@
     <bpmn:boundaryEvent id="Event_15ycupq" name="Chaos Experiment failed" attachedToRef="Activity_1neh8m1">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=append(testReport.failureMessages, (&#34; Experiment failed for cluster plan: &#39;&#34; + clusterPlan + &#34;&#39;.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Experiment failed for cluster plan: &#39;&#34; + clusterPlan + &#34;&#39; against cluster &#39;&#34; + clusterName + &#34;&#39; (&#34; + clusterId + &#34;).&#34;))" target="testReport.failureMessages" />
           <zeebe:output source="= 1" target="testReport.failureCount" />
           <zeebe:output source="=&#34;FAILED&#34;" target="testReport.testResult" />
           <zeebe:output source="=((now() - date and time(&#34;1970-01-01T00:00Z&#34;)) / duration(&#34;PT1S&#34;)) * 1000" target="testReport.endTime" />
@@ -114,45 +114,18 @@
         <di:waypoint x="248" y="225" />
         <di:waypoint x="290" y="225" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1a5ox0j_di" bpmnElement="Activity_0a7hels">
-        <dc:Bounds x="290" y="185" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_152ucof_di" bpmnElement="Event_152ucof">
-        <dc:Bounds x="1022" y="207" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1010" y="250" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0fhnwbl_di" bpmnElement="Event_0fhnwbl">
-        <dc:Bounds x="1022" y="452" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1009" y="495" width="62" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="212" y="207" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="200" y="250" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1a5ox0j_di" bpmnElement="Activity_0a7hels">
+        <dc:Bounds x="290" y="185" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05ujwws_di" bpmnElement="Activity_1neh8m1" isExpanded="true">
         <dc:Bounds x="450" y="80" width="510" height="320" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1jze8zi_di" bpmnElement="Flow_1jze8zi">
-        <di:waypoint x="518" y="220" />
-        <di:waypoint x="580" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19ibrle_di" bpmnElement="Flow_19ibrle">
-        <di:waypoint x="680" y="220" />
-        <di:waypoint x="745" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bp4b07_di" bpmnElement="Flow_0bp4b07">
-        <di:waypoint x="795" y="220" />
-        <di:waypoint x="872" y="220" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="824" y="202" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lzo5zw_di" bpmnElement="Flow_0lzo5zw">
         <di:waypoint x="770" y="245" />
         <di:waypoint x="770" y="330" />
@@ -161,16 +134,40 @@
           <dc:Bounds x="778" y="285" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Gateway_0k7901b_di" bpmnElement="Gateway_0k7901b" isMarkerVisible="true">
-        <dc:Bounds x="745" y="195" width="50" height="50" />
+      <bpmndi:BPMNEdge id="Flow_0bp4b07_di" bpmnElement="Flow_0bp4b07">
+        <di:waypoint x="795" y="220" />
+        <di:waypoint x="872" y="220" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="740" y="156" width="61" height="27" />
+          <dc:Bounds x="824" y="202" width="19" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jze8zi_di" bpmnElement="Flow_1jze8zi">
+        <di:waypoint x="518" y="220" />
+        <di:waypoint x="580" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ibrle_di" bpmnElement="Flow_19ibrle">
+        <di:waypoint x="680" y="220" />
+        <di:waypoint x="745" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0nrb96x_di" bpmnElement="Activity_1a7lifm">
+        <dc:Bounds x="580" y="180" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1riaxno_di" bpmnElement="Event_1riaxno">
         <dc:Bounds x="872" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="846" y="245" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c2kswe_di" bpmnElement="Event_0c2kswe">
+        <dc:Bounds x="482" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="472" y="245" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0k7901b_di" bpmnElement="Gateway_0k7901b" isMarkerVisible="true">
+        <dc:Bounds x="745" y="195" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="740" y="156" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0276x3q_di" bpmnElement="Event_0206bt7">
@@ -179,13 +176,16 @@
           <dc:Bounds x="845" y="355" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0nrb96x_di" bpmnElement="Activity_1a7lifm">
-        <dc:Bounds x="580" y="180" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0c2kswe_di" bpmnElement="Event_0c2kswe">
-        <dc:Bounds x="482" y="202" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0fhnwbl_di" bpmnElement="Event_0fhnwbl">
+        <dc:Bounds x="1022" y="452" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="472" y="245" width="56" height="14" />
+          <dc:Bounds x="1009" y="495" width="62" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_152ucof_di" bpmnElement="Event_152ucof">
+        <dc:Bounds x="1022" y="207" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1010" y="250" width="61" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_05qv9kd_di" bpmnElement="Event_15ycupq">


### PR DESCRIPTION
Add more context to the failure messages. The timeout is set as variable
such we can use it inside our failure report. Furthermore the cluster
name and cluster id is added to the report.

![failure](https://user-images.githubusercontent.com/2758593/118462722-47a76300-b6ff-11eb-8aa4-07d78d6c610d.png)

```json
{
	"startTime": 1621240328000,
	"testResult": "FAILED",
	"failureCount": 1,
	"endTime": 1621241229000,
	"failureMessages": [
		" Action with name: 'All pods should be ready' timed out after PT900S.",
		" Chaos experiment 'Zeebe deployment distribution' failed.",
		" Experiment failed for cluster plan: 'Production - M' against cluster 'Cluster Under Test' (c0ba034d-b433-4f99-a1ff-68a20bd9f0f1)."
	]
}
```