### PR TITLE
Improve chaos logging

### DIFF
--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -55,6 +55,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+      <version>${zeebe.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/AwaitMessageCorrelationHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/AwaitMessageCorrelationHandler.kt
@@ -25,6 +25,7 @@ class AwaitMessageCorrelationHandler(val createClient: (ActivatedJob) -> ZeebeCl
     }
 
     override fun handle(client: JobClient, job: ActivatedJob) {
+        setMDCForJob(job)
         LOG.info("Handle job $JOB_TYPE")
 
         createClient(job).use {

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/AwaitProcessWithResultHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/AwaitProcessWithResultHandler.kt
@@ -22,6 +22,7 @@ class AwaitProcessWithResultHandler(val createClient: (ActivatedJob) -> ZeebeCli
     }
 
     override fun handle(client: JobClient, job: ActivatedJob) {
+        setMDCForJob(job)
         LOG.info("Handle job $JOB_TYPE")
 
         createClient(job).use {

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -23,6 +23,7 @@ class DeployMultipleVersionsHandler(val createClient: (ActivatedJob) -> ZeebeCli
     }
 
     override fun handle(client: JobClient, job: ActivatedJob) {
+        setMDCForJob(job)
         LOG.info("Handle job $JOB_TYPE")
 
         createClient(job).use {

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -7,7 +7,12 @@ import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
 import org.awaitility.Awaitility
 import org.awaitility.pollinterval.FibonacciPollInterval
+import org.slf4j.MDC
+import java.io.BufferedReader
 import java.io.File
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
@@ -94,6 +99,7 @@ private fun initializeAwaitility() {
 }
 
 fun readExperiments(client: JobClient, activatedjob: ActivatedJob) {
+    setMDCForJob(activatedjob)
     val clusterPlan = activatedjob
         .variablesAsMap["clusterPlan"]!!
         .toString()
@@ -111,7 +117,10 @@ fun readExperiments(client: JobClient, activatedjob: ActivatedJob) {
 }
 
 fun handler(client: JobClient, activatedjob: ActivatedJob) {
-    val namespace = (activatedjob.variablesAsMap["clusterId"]!! as String) + "-zeebe"
+    val clusterId = activatedjob.variablesAsMap["clusterId"]!! as String
+    setMDCForJob(activatedjob)
+
+    val namespace = "$clusterId-zeebe"
     prepareForChaosExperiments(namespace)
 
     val provider = activatedjob.variablesAsMap["provider"]!! as Map<String, Any>
@@ -120,9 +129,9 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
 
     val commandList = createCommandList(scriptPath, command, provider)
     LOG.info("Commands to run: $commandList")
+
     val processBuilder = ProcessBuilder(commandList)
         .directory(scriptPath)
-        .inheritIO()
     processBuilder
         .environment()["NAMESPACE"] = namespace
 
@@ -132,12 +141,24 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
     }
 
     val process = processBuilder.start()
+    consumeOutputStream(process.inputStream)
+    consumeOutputStream(process.errorStream)
     val inTime = process.waitFor(timeoutInSeconds, TimeUnit.SECONDS)
 
     if (inTime && process.exitValue() == 0) {
         client.newCompleteCommand(activatedjob.key).send()
     } else {
         process.destroyForcibly()
+    }
+}
+
+internal fun consumeOutputStream(inputStream : InputStream) {
+    Thread().run {
+        BufferedReader(InputStreamReader(inputStream, UTF_8)).use { reader ->
+            reader.forEachLine {
+                LOG.debug(it)
+            }
+        }
     }
 }
 
@@ -249,4 +270,16 @@ internal fun succeeds(
         exceptionHandler.invoke(exc)
         false
     }
+}
+
+internal fun setMDCForJob(job: ActivatedJob) {
+    MDC.put("jobType", job.type)
+
+    val clusterId = job.variablesAsMap["clusterId"]!! as String
+    MDC.put("clusterId", clusterId)
+
+    val clusterPlan = job.variablesAsMap["clusterPlan"]!! as String
+    MDC.put("clusterPlan", clusterPlan)
+
+    MDC.put("processInstanceId", job.processInstanceKey.toString())
 }

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -281,5 +281,5 @@ internal fun setMDCForJob(job: ActivatedJob) {
     val clusterPlan = job.variablesAsMap["clusterPlan"]!! as String
     MDC.put("clusterPlan", clusterPlan)
 
-    MDC.put("processInstanceId", job.processInstanceKey.toString())
+    MDC.put("processInstanceKey", job.processInstanceKey.toString())
 }

--- a/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
+++ b/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
@@ -1,19 +1,40 @@
-<Configuration status="WARN" strict="true"
-xmlns="http://logging.apache.org/log4j/2.0/config"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://raw.githubusercontent.com/apache/logging-log4j2/log4j-2.8.1/log4j-core/src/main/resources/Log4j-config.xsd">
-<Appenders>
-  <Console name="Console" target="SYSTEM_OUT">
-    <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level Java Client: %logger{36} - %msg%n"/>
-  </Console>
-</Appenders>
-<Loggers>
-  <Logger name="io.zeebe.bpmnspec" level="trace"/>
-  <Logger name="io.zeebe.chaos" level="debug"/>
-  <Logger name="io.zeebe" level="info"/>
-  <Logger name="io.zeebe.client.job.poller" level="error"/>
-  <Root level="error">
-    <AppenderRef ref="Console"/>
-  </Root>
-</Loggers>
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" shutdownHook="disable">
+  <Properties>
+    <Property name="log.path">logs</Property>
+    <Property name="log.stackdriver.serviceName">chaos-worker</Property>
+    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}
+    </Property>
+  </Properties>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level Java Client: %logger{36} - %msg%n"/>
+    </Console>
+
+    <Console name="Stackdriver" target="SYSTEM_OUT">
+      <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
+        serviceVersion="${log.stackdriver.serviceVersion}"/>
+    </Console>
+
+    <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
+      filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
+      <Policies>
+        <TimeBasedTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="250 MB"/>
+      </Policies>
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.zeebe.bpmnspec" level="trace"/>
+    <Logger name="io.zeebe.chaos" level="debug"/>
+    <Logger name="io.zeebe" level="info"/>
+    <Logger name="io.zeebe.client.job.poller" level="error"/>
+
+    <Root level="info">
+      <AppenderRef ref="RollingFile"/>
+      <AppenderRef ref="Stackdriver"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
+++ b/core/chaos-workers/chaos-worker/src/main/resources/log4j2.xml
@@ -3,8 +3,7 @@
   <Properties>
     <Property name="log.path">logs</Property>
     <Property name="log.stackdriver.serviceName">chaos-worker</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}
-    </Property>
+    <Property name="log.stackdriver.serviceVersion">2.0.0</Property>
   </Properties>
 
   <Appenders>


### PR DESCRIPTION
1. In order to log via json layout, which is better visible and processed
by stackdriver, this commits adds a dependency to the zeebe-util module
and uses the StackDriverLayout
2. Use MDC for logging, add as context information:

 * the job type
 * cluster id
 * cluster plan
 * process instance id
3. Furthermore the process logs are redirected to log4j and uses the
correct context


Example output:

```
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"function":"invoke","file":"chaosMain.kt","line":159},"message":"+ kubectl wait --for=condition=Ready pod -l app.kubernetes.io/app=zeebe --timeout=900s -n 0ee5902e-1dfa-4805-9eb2-51d8036faaa2-zeebe","serviceContext":{"service":"chaos-worker","version":"development"},"context":{"clusterPlan":"Production - M","threadId":25,"processInstanceId":"4503599627372936","clusterId":"0ee5902e-1dfa-4805-9eb2-51d8036faaa2","jobType":"verify-readiness.sh","threadPriority":5,"loggerName":"io.zeebe.chaos.ChaosWorker","threadName":"pool-3-thread-1"},"timestampSeconds":1621427016,"timestampNanos":690601000}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"function":"invoke","file":"chaosMain.kt","line":159},"message":"error: no matching resources found","serviceContext":{"service":"chaos-worker","version":"development"},"context":{"clusterPlan":"Production - M","threadId":25,"processInstanceId":"4503599627372936","clusterId":"0ee5902e-1dfa-4805-9eb2-51d8036faaa2","jobType":"verify-readiness.sh","threadPriority":5,"loggerName":"io.zeebe.chaos.ChaosWorker","threadName":"pool-3-thread-1"},"timestampSeconds":1621427016,"timestampNanos":691035000}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"run","file":"chaosMain.kt","line":87},"message":"Received shutdown signal","serviceContext":{"service":"chaos-worker","version":"development"},"context":{"threadId":33,"threadPriority":5,"loggerName":"io.zeebe.chaos.ChaosWorker","threadName":"Close thread"},"timestampSeconds":1621427054,"timestampNanos":479319000}
```

Interesting is the context part:

```
"context":{"clusterPlan":"Production - M","threadId":25,"processInstanceId":"4503599627372936","clusterId":"0ee5902e-1dfa-4805-9eb2-51d8036faaa2","jobType":"verify-readiness.sh","threadPriority":5,"loggerName":"io.zeebe.chaos.ChaosWorker","threadName":"pool-3-thread-1"}
```

which we can use for filtering in stackdriver