### PR TITLE
fix(chaos): replace assembly with shade plugin

### DIFF
--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -22,7 +22,7 @@ RUN kubectl config set-context ${CONTEXT} --user ${CONTEXT}-zeebe-chaos-token-us
 
 FROM pre as runner
 
-COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*-jar-with-dependencies.jar chaosWorker.jar
+COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*.jar chaosWorker.jar
 
 # ./runWorker.sh
 CMD java -jar chaosWorker.jar

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -102,26 +102,31 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
         <configuration>
-          <archive>
-            <manifest>
+          <transformers>
+            <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
+            <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
-            </manifest>
-          </archive>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+            </transformer>
+          </transformers>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.6.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>make-assembly</id>
-            <!-- bind to the packaging phase -->
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <!-- this is used for inheritance merges -->
             <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
In order to fix our Log4J issue, which was caused by the assembly plugin
and building a jar with dependencies, we need to replace the assembly
plugin with the shade plugin and use a third-party plugin to make sure
that the log4j plugin dat file is correctly merged with all
dependencies.

This makes it possible to have the strackdriver logging and building a
jar with dependencies.

Found it via https://stackoverflow.com/questions/25065580/log4j2-custom-plugins-annotation-processing-with-maven-assembly-plugin and https://maven.apache.org/plugins/maven-shade-plugin/examples/executable-jar.html