### PR TITLE
Fix docker build

### DIFF
--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -22,7 +22,7 @@ RUN kubectl config set-context ${CONTEXT} --user ${CONTEXT}-zeebe-chaos-token-us
 
 FROM pre as runner
 
-COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*.jar chaosWorker.jar
+COPY chaos-worker/target/chaosWorker.jar chaosWorker.jar
 
 # ./runWorker.sh
 CMD java -jar chaosWorker.jar

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -86,12 +86,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>${plugin.version..maven.exec}</version>
@@ -103,22 +97,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>${plugin.version.shade}</version>
         <configuration>
-          <transformers>
-            <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
-            <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
-            </transformer>
-          </transformers>
-          <finalName>chaosWorker.jar</finalName>
+          <finalName>chaosWorker</finalName>
         </configuration>
         <dependencies>
           <dependency>
             <groupId>com.github.edwgiz</groupId>
             <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-            <version>2.6.1</version>
+            <version>${version.log4j2-cachefile}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -128,6 +115,15 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <transformers>
+                <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
+                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -112,6 +112,7 @@
               <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
             </transformer>
           </transformers>
+          <finalName>chaosWorker.jar</finalName>
         </configuration>
         <dependencies>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <properties>
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/</nexus.release.repository>
     <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</nexus.snapshot.repository>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <plugin.version.build-helper>3.2.0</plugin.version.build-helper>
     <plugin.version.checkstyle>3.1.2</plugin.version.checkstyle>
     <plugin.version.dependency>3.1.2</plugin.version.dependency>
@@ -50,7 +51,8 @@
     <plugin.version.pitest>1.3.7</plugin.version.pitest>
     <plugin.version.pitest-junit5>0.14</plugin.version.pitest-junit5>
     <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <plugin.version.shade>3.2.4</plugin.version.shade>
+    <version.log4j2-cachefile>2.14.1</version.log4j2-cachefile>
     <version.assertj>3.19.0</version.assertj>
     <version.awaitility>4.1.0</version.awaitility>
     <version.commons-text>1.9</version.commons-text>


### PR DESCRIPTION
In order to reference the jar with dependencies this commit gives it a
unique name without artifact or version, which is used in the Dockerfile
as well

Refactored the chaos worker pom a bit:

 * Introduce version properties and migrated to newer version
 * Small clean up of pom (remove unused plugins)