### PR TITLE
fix(chaos): print system error together with system out

### DIFF
--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -17,6 +17,7 @@ import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 private const val ENV_TESTBENCH_ADDRESS = "TESTBENCH_ADDRESS"
 private const val ENV_TESTBENCH_CLIENT_ID = "TESTBENCH_CLIENT_ID"
@@ -140,9 +141,11 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
         timeoutInSeconds = provider["timeout"].toString().toLong()
     }
 
+    // redirects the error stream to the output stream
+    processBuilder.redirectErrorStream(true)
     val process = processBuilder.start()
+    // the input stream of the process object is connected to the output stream we want to consume, don't ask.
     consumeOutputStream(process.inputStream)
-    consumeOutputStream(process.errorStream)
     val inTime = process.waitFor(timeoutInSeconds, TimeUnit.SECONDS)
 
     if (inTime && process.exitValue() == 0) {
@@ -152,8 +155,8 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
     }
 }
 
-internal fun consumeOutputStream(inputStream : InputStream) {
-    Thread().run {
+internal fun consumeOutputStream(inputStream: InputStream) {
+    thread(start = true) {
         BufferedReader(InputStreamReader(inputStream, UTF_8)).use { reader ->
             reader.forEachLine {
                 LOG.debug(it)


### PR DESCRIPTION
Previously the output streams have been printed after another, which can
cause confusion and makes it not really visible what is happening.

Furthermore the worker thread was blocked, until the process was done.
This cause problems on handling jobs, not terminating the process after
some time and we are not seeing what is going on.

For more information read https://github.com/zeebe-io/zeebe-cluster-testbench/issues/368

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/368

Sorry with bothering you all the time @pihme 