### PR TITLE
[Backport 0.26] Backport several chaos worker fixes 

### DIFF
--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -23,7 +23,7 @@ RUN kubectl config set-context ${CONTEXT} --user ${CONTEXT}-zeebe-chaos-token-us
 
 FROM pre as runner
 
-COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*-jar-with-dependencies.jar chaosWorker.jar
+COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*.jar chaosWorker.jar
 
 # ./runWorker.sh
 CMD java -jar chaosWorker.jar

--- a/core/chaos-workers/Dockerfile
+++ b/core/chaos-workers/Dockerfile
@@ -23,7 +23,7 @@ RUN kubectl config set-context ${CONTEXT} --user ${CONTEXT}-zeebe-chaos-token-us
 
 FROM pre as runner
 
-COPY chaos-worker/target/zeebe-cluster-testbench-chaos-worker-*.jar chaosWorker.jar
+COPY chaos-worker/target/chaosWorker.jar chaosWorker.jar
 
 # ./runWorker.sh
 CMD java -jar chaosWorker.jar

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -77,6 +77,7 @@
               <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
             </transformer>
           </transformers>
+          <finalName>chaosWorker.jar</finalName>
         </configuration>
         <dependencies>
           <dependency>

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -67,23 +67,30 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
         <configuration>
-          <archive>
-            <manifest>
+          <transformers>
+            <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
+            <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
-            </manifest>
-          </archive>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+            </transformer>
+          </transformers>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.6.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>make-assembly</id> <!-- this is used for inheritance merges -->
-            <phase>package</phase> <!-- bind to the packaging phase -->
+            <id>make-assembly</id>
+            <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
           </execution>
         </executions>

--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -51,12 +51,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>${plugin.version..maven.exec}</version>
@@ -68,22 +62,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>${plugin.version.shade}</version>
         <configuration>
-          <transformers>
-            <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
-            <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
-            </transformer>
-          </transformers>
-          <finalName>chaosWorker.jar</finalName>
+          <finalName>chaosWorker</finalName>
         </configuration>
         <dependencies>
           <dependency>
             <groupId>com.github.edwgiz</groupId>
             <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-            <version>2.6.1</version>
+            <version>${version.log4j2-cachefile}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -93,6 +80,15 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <transformers>
+                <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
+                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -126,7 +126,7 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
     processBuilder.redirectErrorStream(true)
     val process = processBuilder.start()
     // the input stream of the process object is connected to the output stream we want to consume, don't ask.
-    consumeOutputStream(process.inputStream)
+    consumeOutputStream(activatedjob, process.inputStream)
     val inTime = process.waitFor(timeoutInSeconds, TimeUnit.SECONDS)
 
     if (inTime && process.exitValue() == 0) {
@@ -136,8 +136,9 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
     }
 }
 
-internal fun consumeOutputStream(inputStream: InputStream) {
+internal fun consumeOutputStream(job : ActivatedJob, inputStream: InputStream) {
     thread(start = true) {
+        setMDCForJob(job)
         BufferedReader(InputStreamReader(inputStream, UTF_8)).use { reader ->
             reader.forEachLine {
                 LOG.debug(it)

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 private const val ENV_TESTBENCH_ADDRESS = "TESTBENCH_ADDRESS"
 private const val ENV_TESTBENCH_CLIENT_ID = "TESTBENCH_CLIENT_ID"
@@ -121,9 +122,11 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
         timeoutInSeconds = provider["timeout"].toString().toLong()
     }
 
+    // redirects the error stream to the output stream
+    processBuilder.redirectErrorStream(true)
     val process = processBuilder.start()
+    // the input stream of the process object is connected to the output stream we want to consume, don't ask.
     consumeOutputStream(process.inputStream)
-    consumeOutputStream(process.errorStream)
     val inTime = process.waitFor(timeoutInSeconds, TimeUnit.SECONDS)
 
     if (inTime && process.exitValue() == 0) {
@@ -133,8 +136,8 @@ fun handler(client: JobClient, activatedjob: ActivatedJob) {
     }
 }
 
-internal fun consumeOutputStream(inputStream : InputStream) {
-    Thread().run {
+internal fun consumeOutputStream(inputStream: InputStream) {
+    thread(start = true) {
         BufferedReader(InputStreamReader(inputStream, UTF_8)).use { reader ->
             reader.forEachLine {
                 LOG.debug(it)

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,7 @@
     <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
     <plugin.version.pitest>1.3.7</plugin.version.pitest>
     <plugin.version.pitest-junit5>0.14</plugin.version.pitest-junit5>
+    <plugin.version.shade>3.2.4</plugin.version.shade>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.assertj>3.19.0</version.assertj>
@@ -424,6 +425,7 @@
 
     <version.junit>5.7.2</version.junit>
     <version.log4j>2.14.1</version.log4j>
+    <version.log4j2-cachefile>2.14.1</version.log4j2-cachefile>
     <version.mockito>3.10.0</version.mockito>
     <version.resteasy>4.6.0.Final</version.resteasy>
     <version.slf4j>1.7.30</version.slf4j>


### PR DESCRIPTION
Backports several chaos worker fixes to align the chaos worker with 1.0 and make it possible to use the stackdriver logging also on 0.26.

Backport https://github.com/zeebe-io/zeebe-cluster-testbench/pull/365
Backport https://github.com/zeebe-io/zeebe-cluster-testbench/pull/366
Backport https://github.com/zeebe-io/zeebe-cluster-testbench/pull/369
Backport https://github.com/zeebe-io/zeebe-cluster-testbench/commit/6ead6e0858833085b43e05c98923ba5dc407f312

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/370