### PR TITLE
[chaos] Use expressive multi version process name

### DIFF
--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -12,9 +12,9 @@ class DeployMultipleVersionsHandler(val createClient: (ActivatedJob) -> ZeebeCli
 
     private val PROCESS_ID = "multiVersion"
     private val MODEL_V1 =
-        Bpmn.createExecutableProcess(PROCESS_ID).name("v1").startEvent().endEvent().done()
+        Bpmn.createExecutableProcess(PROCESS_ID).name("Multi version process").startEvent("start-1").endEvent().done()
     private val MODEL_V2 =
-        Bpmn.createExecutableProcess(PROCESS_ID).name("v2").startEvent().endEvent().done()
+        Bpmn.createExecutableProcess(PROCESS_ID).name("Multi version process").startEvent("start-2").endEvent().done()
     private val LOG =
         org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.DeployMultipleVersionsHandler")
 


### PR DESCRIPTION
In operate, it is strange to see v1 or v2 as a process name. To make
analysis easier, let's change the name of the multi-version process to
something more expressive