### PR TITLE
Improve multi version deploy

### DIFF
--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -26,9 +26,9 @@ class DeployMultipleVersionsHandler : JobHandler {
         createClientForClusterUnderTest(job).use { clusterUnderTest ->
             LOG.info("Connected to ${clusterUnderTest.configuration.gatewayAddress}, start deploying multiple versions...")
 
-            val lastVersion = IntRange(1, 10)
-                    .map{i -> waitForModelDeployment(clusterUnderTest, i)}
-                    .map{e -> e?.processes?.get(0)?.version ?: -1 }
+            val lastVersion = (1..10)
+                    .map{ waitForModelDeployment(clusterUnderTest, it) }
+                    .map{ it?.processes?.get(0)?.version ?: -1 }
                     .last()
 
             if (lastVersion < 10) {

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -6,6 +6,8 @@ import io.camunda.zeebe.client.api.worker.JobClient
 import io.camunda.zeebe.client.api.worker.JobHandler
 import io.camunda.zeebe.model.bpmn.Bpmn
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
+import org.awaitility.kotlin.await
+import java.util.concurrent.TimeUnit
 
 class DeployMultipleVersionsHandler(val createClient: (ActivatedJob) -> ZeebeClient = ::createClientForClusterUnderTest) :
     JobHandler {
@@ -31,7 +33,7 @@ class DeployMultipleVersionsHandler(val createClient: (ActivatedJob) -> ZeebeCli
 
             var lastVersion = -1
             for (i in 1..5) {
-                it.deployModel(MODEL_V1, "modelV1.bpmn")
+                await.until { -> it.deployModel(MODEL_V1, "modelV1.bpmn") }
                 lastVersion = waitForModelDeployment(it, MODEL_V2, "modelV2.bpmn")
             }
 

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -51,7 +51,7 @@ class DeployMultipleVersionsHandler(val createClient: (ActivatedJob) -> ZeebeCli
             event = client.newDeployCommand()
                     .addProcessModel(
                             Bpmn.createExecutableProcess(PROCESS_ID)
-                                    .name("v1")
+                                    .name("Multi version process")
                                     .startEvent("start-" + index)
                                     .endEvent()
                                     .done(),

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -32,10 +32,12 @@ class DeployMultipleVersionsHandler : JobHandler {
                     .last()
 
             if (lastVersion < 10) {
-                LOG.warn("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Fail $JOB_TYPE")
+                val message =
+                    "Expected to deploy 10 different versions of process $PROCESS_ID, but only deployed $lastVersion"
+                LOG.warn("$message. Fail $JOB_TYPE")
                 testbench.newFailCommand(job.key)
                         .retries(job.retries)
-                        .errorMessage("Expected to deploy 10 different versions of process $PROCESS_ID, but only deployed $lastVersion")
+                        .errorMessage(message)
                         .send()
             } else {
                 LOG.info("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Complete $JOB_TYPE")


### PR DESCRIPTION
It could happen that deployment of the initial version of the
multiVersion process would fail. The handler awaits deployment of the
successive versions and in the end expects that 10 different versions
were deployed, but this could be lower if one of the model_v1
deployments failed.

By reworking the multi version deployment to a collection pipeline, it becomes much more clear 
what happens and when things go wrong. This also allows us to respond to failure cases.
The job can be failed (keeping retries the same) when multi version deployment fails.

This failure should not affect the standard timer boundary event that times out if the task is not 
completed on time (in actionRunner.bpmn).

