### PR TITLE
Backport 389 to stable/0.26

### DIFF
--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -117,6 +117,15 @@
       <artifactId>zeebe-util</artifactId>
       <version>${zeebe.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility-kotlin</artifactId>
+    </dependency>
   </dependencies>
 
 

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -2,19 +2,19 @@ package io.zeebe.chaos;
 
 import io.zeebe.client.ZeebeClient
 import io.zeebe.client.api.response.ActivatedJob
+import io.zeebe.client.api.response.DeploymentEvent
 import io.zeebe.client.api.worker.JobClient
 import io.zeebe.client.api.worker.JobHandler
 import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder
 import io.zeebe.model.bpmn.Bpmn
-import io.zeebe.model.bpmn.BpmnModelInstance
-import org.camunda.bpm.model.xml.ModelInstance
+import org.awaitility.kotlin.await
 
 class DeployMultipleVersionsHandler : JobHandler {
 
     private val PROCESS_ID = "multiVersion"
-    private val MODEL_V1 = Bpmn.createExecutableProcess(PROCESS_ID).name("v1").startEvent().endEvent().done()
-    private val MODEL_V2 = Bpmn.createExecutableProcess(PROCESS_ID).name("v2").startEvent().endEvent().done()
-    private val LOG = org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.DeployMultipleVersionsHandler")
+    private val RESOURCE_NAME = PROCESS_ID +".bpmn"
+    private val LOG =
+        org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.DeployMultipleVersionsHandler")
 
     companion object {
         const val JOB_TYPE = "deploy-different-versions.sh"
@@ -28,11 +28,10 @@ class DeployMultipleVersionsHandler : JobHandler {
         createClient(authenticationDetails).use {
             LOG.info("Connected to ${it.configuration.gatewayAddress}, start deploying multiple versions...")
 
-            var lastVersion = -1
-            for (i in 1..5) {
-                deployModel(it, MODEL_V1, "modelV1.bpmn")
-                lastVersion = deployModel(it, MODEL_V2, "modelV2.bpmn")
-            }
+            val lastVersion = IntRange(1, 10)
+                    .map{i -> waitForModelDeployment(it, i)}
+                    .map{e -> e?.workflows?.get(0)?.version ?: -1 }
+                    .last()
 
             LOG.info("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Complete $JOB_TYPE")
         }
@@ -40,21 +39,22 @@ class DeployMultipleVersionsHandler : JobHandler {
         client.newCompleteCommand(job.key).send()
     }
 
-    private fun deployModel(client: ZeebeClient, model: BpmnModelInstance, name: String) : Int{
-        var version = -1
-        do {
-            try {
-                val deploymentEvent = client.newDeployCommand().addWorkflowModel(model, name).send().join()
-                version = deploymentEvent.workflows[0].version
-            } catch (e: Exception) {
-                // try again
-                LOG.debug("Failed to deploy $name, try again.", e)
-                Thread.sleep(100)
-            }
-        } while (version == -1)
-        return version
+    private fun waitForModelDeployment(client: ZeebeClient, index: Int): DeploymentEvent? {
+        var event: DeploymentEvent? = null
+        await.untilAsserted {
+            event = client.newDeployCommand()
+                    .addWorkflowModel(
+                            Bpmn.createExecutableProcess(PROCESS_ID)
+                                    .name("v1")
+                                    .startEvent("start-" + index)
+                                    .endEvent()
+                                    .done(),
+                            RESOURCE_NAME)
+                    .send()
+                    .join()
+        }
+        return event
     }
-
 
     private fun createClient(authenticationDetails: Map<String, Any>): ZeebeClient {
         val clientId = authenticationDetails["clientId"]!!.toString()

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -27,9 +27,9 @@ class DeployMultipleVersionsHandler : JobHandler {
         createClientForClusterUnderTest(job).use { clusterUnderTest ->
             LOG.info("Connected to ${clusterUnderTest.configuration.gatewayAddress}, start deploying multiple versions...")
 
-            val lastVersion = IntRange(1, 10)
-                    .map{i -> waitForModelDeployment(clusterUnderTest, i)}
-                    .map{e -> e?.workflows?.get(0)?.version ?: -1 }
+            val lastVersion = (1..10)
+                    .map{ waitForModelDeployment(clusterUnderTest, it) }
+                    .map{ it?.workflows?.get(0)?.version ?: -1 }
                     .last()
 
             if (lastVersion < 10) {

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -52,7 +52,7 @@ class DeployMultipleVersionsHandler : JobHandler {
             event = client.newDeployCommand()
                     .addWorkflowModel(
                             Bpmn.createExecutableProcess(PROCESS_ID)
-                                    .name("v1")
+                                    .name("Multi version process")
                                     .startEvent("start-" + index)
                                     .endEvent()
                                     .done(),

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -33,10 +33,12 @@ class DeployMultipleVersionsHandler : JobHandler {
                     .last()
 
             if (lastVersion < 10) {
-                LOG.warn("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Fail $JOB_TYPE")
+                val message =
+                    "Expected to deploy 10 different versions of process $PROCESS_ID, but only deployed $lastVersion"
+                LOG.warn("$message. Fail $JOB_TYPE")
                 testbench.newFailCommand(job.key)
                         .retries(job.retries)
-                        .errorMessage("Expected to deploy 10 different versions of process $PROCESS_ID, but only deployed $lastVersion")
+                        .errorMessage(message)
                         .send()
             } else {
                 LOG.info("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Complete $JOB_TYPE")

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/DeployMultipleVersionsHandler.kt
@@ -33,10 +33,17 @@ class DeployMultipleVersionsHandler : JobHandler {
                     .map{e -> e?.workflows?.get(0)?.version ?: -1 }
                     .last()
 
-            LOG.info("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Complete $JOB_TYPE")
+            if (lastVersion < 10) {
+                LOG.warn("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Fail $JOB_TYPE")
+                client.newFailCommand(job.key)
+                        .retries(job.retries)
+                        .errorMessage("Expected to deploy 10 different versions of process $PROCESS_ID, but only deployed $lastVersion")
+                        .send()
+            } else {
+                LOG.info("Deployed 10 different versions of process $PROCESS_ID, last version: $lastVersion. Complete $JOB_TYPE")
+                client.newCompleteCommand(job.key).send()
+            }
         }
-
-        client.newCompleteCommand(job.key).send()
     }
 
     private fun waitForModelDeployment(client: ZeebeClient, index: Int): DeploymentEvent? {

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,11 @@
         <artifactId>awaitility</artifactId>
         <version>${version.awaitility}</version>
       </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility-kotlin</artifactId>
+        <version>${version.awaitility}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <groupId>io.zeebe</groupId>


### PR DESCRIPTION
Backports #389 to `stable/0.26`

I needed to add awaitility as a dependency. 

Some of the commits could be directly cherry-picked, those have the [cherry-picked from ..] footer in the commit message, but I also had to move some code around to resolve conflicts, those do not have the [cherry-picked from ..] footer.  