### PR TITLE
Proof of Concept: generate BPMN models from experiment JSON

### DIFF
--- a/core/chaos-workers/chaos-worker/pom.xml
+++ b/core/chaos-workers/chaos-worker/pom.xml
@@ -2,7 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>io.zeebe</groupId>
@@ -11,46 +10,27 @@
     <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
-
+  <modelVersion>4.0.0</modelVersion>
   <artifactId>zeebe-cluster-testbench-chaos-worker</artifactId>
   <packaging>jar</packaging>
   <name>Zeebe Cluster Testbench - Chaos Worker</name>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jackson-module-kotlin.version>2.9.8</jackson-module-kotlin.version>
     <kotlin.code.style>official</kotlin.code.style>
     <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-
-    <version.kotlin>1.4.10</version.kotlin>
-    <version.awatility>4.1.0</version.awatility>
     <plugin.version..maven.exec>3.0.0</plugin.version..maven.exec>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <version.awatility>4.1.0</version.awatility>
+    <version.kotlin>1.4.10</version.kotlin>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-test-junit</artifactId>
-      <version>${version.kotlin}</version>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+      <version>${jackson-module-kotlin.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>${version.kotlin}</version>
-    </dependency>
-
-
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${version.awaitility}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility-kotlin</artifactId>
-      <version>${version.awaitility}</version>
-    </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
@@ -60,40 +40,36 @@
       <artifactId>zeebe-util</artifactId>
       <version>${zeebe.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility-kotlin</artifactId>
+      <version>${version.awaitility}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${version.awaitility}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${version.kotlin}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <version>${zeebe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test-junit</artifactId>
+      <version>${version.kotlin}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${version.kotlin}</version>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${plugin.version..maven.exec}</version>
-        <configuration>
-          <mainClass>ChaosMainKt</mainClass>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -118,8 +94,10 @@
             <configuration>
               <transformers>
                 <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
-                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <transformer
+                  implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer"/>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>io.zeebe.chaos.ChaosMainKt</mainClass>
                 </transformer>
               </transformers>
@@ -127,9 +105,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${plugin.version..maven.exec}</version>
+        <configuration>
+          <mainClass>ChaosMainKt</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${version.kotlin}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <sourceDirectory>src/main/kotlin</sourceDirectory>
     <testSourceDirectory>src/test/kotlin</testSourceDirectory>
   </build>
-
 </project>

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/BpmnGenerator.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/BpmnGenerator.kt
@@ -1,0 +1,128 @@
+package io.zeebe.chaos
+
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder
+import java.time.Duration
+import java.util.*
+
+private const val ERROR_CODE_FAILED_ACTION = "failedAction"
+private const val ID_END_FAILURE = "end_failure"
+private const val ID_INTRODUCE_CHAOS = "introduce_chaos"
+private const val ID_STEADY_STATE_AFTER = "steady_state_after"
+private const val ID_STEADY_STATE_BEFORE = "steady_state_before"
+private const val NAME_CHAOS_EXPERIMENT_FAILED = "Chaos Experiment Failed"
+private const val NAME_VERIFY_STEADY_STATE = "Verify Steady State"
+private const val SUFFIX_ERROR = "_error"
+
+fun toBpmn(
+    clusterPlan: String,
+    experimentName: String,
+    experiment: Experiment
+): BpmnModelInstance {
+    val processId = "${clusterPlan}-${experimentName}"
+
+    var wip: AbstractFlowNodeBuilder<*, *> =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent("start").name("Run Chaos Experiment")
+
+    wip = addVerifySteadyStateSubProcess(ID_STEADY_STATE_BEFORE, wip, experiment)
+
+    wip = addIntroduceChaosSubProcess(wip, experiment)
+
+    wip = addVerifySteadyStateSubProcess(ID_STEADY_STATE_AFTER, wip, experiment)
+
+    wip = wip.endEvent("end_success").name("Chaos Experiment Succeeded")
+
+    wip = addBoundaryErrorEvents(wip)
+
+    return wip.done()
+}
+
+fun addVerifySteadyStateSubProcess(
+    processId: String,
+    wip: AbstractFlowNodeBuilder<*, *>,
+    experiment: Experiment
+): AbstractFlowNodeBuilder<*, *> {
+
+    var result: AbstractFlowNodeBuilder<*, *> =
+        wip.subProcess(processId).name(NAME_VERIFY_STEADY_STATE).embeddedSubProcess()
+            .startEvent()
+
+    for (probe in experiment.steadyState.probes) {
+        val id = "UUID-" + UUID.randomUUID()
+            .toString() //must start with a character, or validtion will fail
+
+        result = result.serviceTask(id).name(probe.name).zeebeJobType(probe.provider.path)
+
+        val timeout = probe.provider.timeout
+        if (timeout > 0) {
+            result =
+                result.boundaryEvent().name("Timeout")
+                    .timerWithDuration(Duration.ofSeconds(timeout).toString()).endEvent().error(
+                        ERROR_CODE_FAILED_ACTION
+                    ).name(NAME_CHAOS_EXPERIMENT_FAILED).moveToNode(
+                        id
+                    )
+        }
+    }
+
+    return result.endEvent()
+        .subProcessDone()
+}
+
+
+fun addIntroduceChaosSubProcess(
+    wip: AbstractFlowNodeBuilder<*, *>,
+    experiment: Experiment
+): AbstractFlowNodeBuilder<*, *> {
+    var result: AbstractFlowNodeBuilder<*, *> =
+        wip.subProcess(ID_INTRODUCE_CHAOS).name("introduce chaos").embeddedSubProcess()
+            .startEvent()
+
+    for (method in experiment.method) {
+        val id = "UUID-" + UUID.randomUUID()
+            .toString() //must start with a character, or validtion will fail
+        result = result.serviceTask(id).name(method.name).zeebeJobType(method.provider.path)
+
+        val timeout = method.provider.timeout
+        if (timeout > 0) {
+            result =
+                result.boundaryEvent().name("Timeout")
+                    .timerWithDuration(Duration.ofSeconds(timeout).toString()).endEvent().error(
+                        ERROR_CODE_FAILED_ACTION
+                    ).name(NAME_CHAOS_EXPERIMENT_FAILED).moveToNode(
+                        id
+                    )
+        }
+    }
+
+    return result.endEvent()
+        .subProcessDone()
+}
+
+fun addBoundaryErrorEvents(wip: AbstractFlowNodeBuilder<*, *>): AbstractFlowNodeBuilder<*, *> {
+    var result = wip.moveToNode(ID_STEADY_STATE_AFTER)
+
+    result =
+        (result as SubProcessBuilder).boundaryEvent(ID_STEADY_STATE_AFTER + SUFFIX_ERROR)
+            .name(NAME_CHAOS_EXPERIMENT_FAILED)
+            .error("failedAction").endEvent(ID_END_FAILURE)
+            .name("Chaos Experiment tFailed")
+
+    result = result.moveToNode(ID_INTRODUCE_CHAOS)
+
+    result = (result as SubProcessBuilder)
+        .boundaryEvent(ID_INTRODUCE_CHAOS + SUFFIX_ERROR).name(NAME_CHAOS_EXPERIMENT_FAILED)
+        .error("failedAction").connectTo(ID_END_FAILURE)
+
+    result = result.moveToNode(ID_STEADY_STATE_BEFORE)
+
+    result = (result as SubProcessBuilder)
+        .boundaryEvent(ID_STEADY_STATE_BEFORE + SUFFIX_ERROR).name(NAME_CHAOS_EXPERIMENT_FAILED)
+        .error("failedAction").connectTo(ID_END_FAILURE)
+
+    return result
+}
+

--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/Experiment.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/Experiment.kt
@@ -1,0 +1,38 @@
+package io.zeebe.chaos
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Experiment(
+    var title: String,
+    @JsonProperty("steady-state-hypothesis")
+    var steadyState: Hypothesis,
+    var method: List<Method>,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Hypothesis(
+    var title: String?,
+    var probes: List<Probe>
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Probe(
+    var name: String,
+    var provider: Provider
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Method(
+    var type: String,
+    var name: String,
+    var provider: Provider
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Provider(
+    var type: String,
+    var path: String,
+    var timeout: Long
+)


### PR DESCRIPTION
This is not to be reviewed, more to take note of.

This is a proof of concept for the following idea: Based on the `experiment.json` file we could create a BPMN diagram that represents this experiment. Then we could deploy those diagrams and have even more visibility for the experiments.

Example of generated process:
![image](https://user-images.githubusercontent.com/14032870/121685982-e2a61980-cac0-11eb-9f13-68df21d9bf78.png)

This Proof of Concept shows that it can be done. Otherwise, it is not really fleshed out yet.

Just wanted to test this idea, and know what you think of it.