### PR TITLE
Allow unknown properties in responded links

### DIFF
--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/response/ClusterInfo.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/response/ClusterInfo.java
@@ -270,6 +270,7 @@ public class ClusterInfo {
 
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Links {
 
     private String zeebe;


### PR DESCRIPTION
Fixes an incident where the current status of a cluster cannot be queried.

The links property of clusterinfo did not allow any unknown fields, but `zeebeAuthority` has been added.

This PR fixes this by marking the links with the `JsonIgnoreProperties` annotation.
