### PR TITLE
Fix cluster creation

### DIFF
--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/filter/EntityLoggingFilter.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/filter/EntityLoggingFilter.java
@@ -55,11 +55,7 @@ public final class EntityLoggingFilter
   @Override
   public void aroundWriteTo(final WriterInterceptorContext context)
       throws IOException, WebApplicationException {
-    final var stream = (LoggingStream) context.getProperty(ENTITY_STREAM_PROPERTY);
     context.proceed();
-    if (stream != null) {
-      log(stream.getStringBuilder().toString());
-    }
   }
 
   /** Logs the entity and resets the stream it read it from */

--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
@@ -19,6 +19,7 @@ import io.zeebe.clustertestbench.cloud.CloudAPIClient;
 import io.zeebe.clustertestbench.cloud.CloudAPIClientFactory;
 import io.zeebe.clustertestbench.handler.AggregateTestResultHandler;
 import io.zeebe.clustertestbench.handler.CheckGenerationUsageHandler;
+import io.zeebe.clustertestbench.handler.CreateApiClientInCamundaCloudHandler;
 import io.zeebe.clustertestbench.handler.CreateClusterInCamundaCloudHandler;
 import io.zeebe.clustertestbench.handler.CreateGenerationInCamundaCloudHandler;
 import io.zeebe.clustertestbench.handler.DeleteClusterInCamundaCloudHandler;
@@ -251,6 +252,11 @@ public class Launcher {
         client,
         "create-zeebe-cluster-in-camunda-cloud-job",
         new CreateClusterInCamundaCloudHandler(cloudApiClient),
+        Duration.ofMinutes(1));
+    registerWorker(
+        client,
+        "create-api-client-for-cluster-in-camunda-cloud",
+        new CreateApiClientInCamundaCloudHandler(cloudApiClient),
         Duration.ofMinutes(1));
     registerWorker(
         client,

--- a/core/src/main/java/io/zeebe/clustertestbench/handler/CreateApiClientInCamundaCloudHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/CreateApiClientInCamundaCloudHandler.java
@@ -1,0 +1,176 @@
+package io.zeebe.clustertestbench.handler;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.zeebe.clustertestbench.cloud.CloudAPIClient;
+import io.zeebe.clustertestbench.cloud.request.CreateZeebeClientRequest;
+import io.zeebe.clustertestbench.cloud.response.CreateZeebeClientResponse;
+import io.zeebe.clustertestbench.cloud.response.ZeebeClientConnectiontInfo;
+import io.zeebe.clustertestbench.testdriver.api.CamundaCloudAuthenticationDetails;
+import io.zeebe.clustertestbench.testdriver.impl.CamundaCLoudAuthenticationDetailsImpl;
+import java.time.Duration;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateApiClientInCamundaCloudHandler implements JobHandler {
+
+  // https://regex101.com/r/OVAMuf/1
+  private static final String ZEEBE_ADDRESS_PATTERN = "([a-z0-9\\-]+\\.)([a-z0-9\\-]+)(\\.zeebe)";
+  private static final Pattern PATTERN = Pattern.compile(ZEEBE_ADDRESS_PATTERN, Pattern.MULTILINE);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CreateApiClientInCamundaCloudHandler.class);
+
+  private final CloudAPIClient cloudApiClient;
+
+  public CreateApiClientInCamundaCloudHandler(final CloudAPIClient cloudApiClient) {
+    this.cloudApiClient = cloudApiClient;
+  }
+
+  @Override
+  public void handle(final JobClient client, final ActivatedJob job) throws Exception {
+    final var input = job.getVariablesAsType(Input.class);
+    final String clusterId = input.getClusterId();
+    final String clusterName = input.getClusterName();
+    String clientId = null;
+
+    try {
+      LOGGER.info("Creating client for cluster {}", clusterId);
+      final var createZeebeClientResponse =
+          cloudApiClient.createZeebeClient(
+              clusterId, new CreateZeebeClientRequest(clusterName + "_client"));
+      clientId = createZeebeClientResponse.getClientId();
+      LOGGER.info("Created client {} for cluster {}", clientId, clusterId);
+
+      ZeebeClientConnectiontInfo clientInfo;
+      var i = 0;
+      while ((clientInfo = getConnectionInfo(clusterId, clientId)) == null) {
+        // todo: remove this workaround after https://github.com/camunda-cloud/console/issues/2225
+        // After creating the cluster, the region information is not yet available in console.
+        // It takes some time before the info is updated.
+        Thread.sleep(Duration.ofSeconds(10).toMillis());
+        if (i++ >= 3) {
+          final var message =
+              String.format(
+                  "Expected to retrieve connection info for cluster %s and client %s, but fails even after retrying",
+                  clusterId, clientId);
+          LOGGER.error(message);
+          failJob(client, job, clusterId, clientId, message);
+          return;
+        }
+      }
+
+      LOGGER.info("Connection info for client {} retrieved", clientId);
+      client
+          .newCompleteCommand(job.getKey())
+          .variables(new Output(createZeebeClientResponse, clientInfo))
+          .send();
+
+    } catch (final Exception e) {
+      final var message =
+          String.format(
+              "Expected to create a client and retrieve connection info for cluster %s, but failed because: %s",
+              clusterId, e.getMessage());
+      LOGGER.error(message, e);
+      failJob(client, job, clusterId, clientId, message);
+    }
+  }
+
+  @Nullable
+  private ZeebeClientConnectiontInfo getConnectionInfo(
+      final String clusterId, final String clientId) {
+    LOGGER.info("Retrieving connection info for client {} in cluster {}", clientId, clusterId);
+    final ZeebeClientConnectiontInfo clientInfo;
+    try {
+      clientInfo = cloudApiClient.getZeebeClientInfo(clusterId, clientId);
+    } catch (final Exception e) {
+      LOGGER.warn("Expected to retrieve connection info, but an exception occurred", e);
+      return null;
+    }
+
+    if (!PATTERN.matcher(clientInfo.getZeebeAddress()).find()) {
+      final var message =
+          String.format(
+              "Client %s info's zeebe address '%s' does not match '<uuid>.<region>.zeebe'",
+              clientId, clientInfo.getZeebeAddress());
+      LOGGER.warn(message);
+      return null;
+    }
+
+    return clientInfo;
+  }
+
+  private void failJob(
+      final JobClient client,
+      final ActivatedJob job,
+      final String clusterId,
+      final String clientId,
+      final String message) {
+    try {
+      if (clientId != null) {
+        // delete client to keep worker idempotent
+        LOGGER.info("Delete client {} for cluster {}", clientId, clusterId);
+        cloudApiClient.deleteZeebeClient(clusterId, clientId);
+      }
+    } finally {
+      client
+          .newFailCommand(job.getKey())
+          .retries(job.getRetries() - 1)
+          .errorMessage(message)
+          .send();
+    }
+  }
+
+  private static final class Input {
+
+    private String clusterId;
+    private String clusterName;
+
+    public String getClusterId() {
+      return clusterId;
+    }
+
+    public void setClusterId(final String clusterId) {
+      this.clusterId = clusterId;
+    }
+
+    public String getClusterName() {
+      return clusterName;
+    }
+
+    public void setClusterName(final String clusterName) {
+      this.clusterName = clusterName;
+    }
+  }
+
+  private static final class Output {
+
+    private CamundaCLoudAuthenticationDetailsImpl authenticationDetails;
+
+    public Output(
+        final CreateZeebeClientResponse createZeebeClientResponse,
+        final ZeebeClientConnectiontInfo connectionInfo) {
+      this.authenticationDetails =
+          new CamundaCLoudAuthenticationDetailsImpl(
+              connectionInfo.getZeebeAuthorizationServerUrl(),
+              connectionInfo.getZeebeAudience(),
+              connectionInfo.getZeebeAddress(),
+              createZeebeClientResponse.getClientId(),
+              createZeebeClientResponse.getClientSecret());
+    }
+
+    @JsonProperty(CamundaCloudAuthenticationDetails.VARIABLE_KEY)
+    public CamundaCLoudAuthenticationDetailsImpl getAuthenticationDetails() {
+      return authenticationDetails;
+    }
+
+    @JsonProperty(CamundaCloudAuthenticationDetails.VARIABLE_KEY)
+    public void setAuthenticationDetails(
+        final CamundaCLoudAuthenticationDetailsImpl authenticationDetails) {
+      this.authenticationDetails = authenticationDetails;
+    }
+  }
+}

--- a/processes/prepare-zeebe-cluster-in-camunda-cloud.bpmn
+++ b/processes/prepare-zeebe-cluster-in-camunda-cloud.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_10jos80" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_10jos80" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
   <bpmn:process id="prepare-zeebe-cluster-in-camunda-cloud" name="Prepare Zeebe Cluster in Camunda Cloud" isExecutable="true">
     <bpmn:startEvent id="start" name="Start">
       <bpmn:outgoing>Flow_0v89qt6</bpmn:outgoing>
@@ -13,11 +13,11 @@
       <bpmn:outgoing>Flow_0f4lf0m</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0h5nxf3">
-      <bpmn:incoming>Flow_0f4lf0m</bpmn:incoming>
       <bpmn:incoming>Flow_1t5mjg2</bpmn:incoming>
+      <bpmn:incoming>Flow_16dvxg9</bpmn:incoming>
       <bpmn:outgoing>Flow_1nplddv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0f4lf0m" sourceRef="create-zeebe-cluster-in-camunda-cloud" targetRef="Gateway_0h5nxf3" />
+    <bpmn:sequenceFlow id="Flow_0f4lf0m" sourceRef="create-zeebe-cluster-in-camunda-cloud" targetRef="create-api-client-for-cluster-in-camunda-cloud" />
     <bpmn:sequenceFlow id="Flow_1nplddv" sourceRef="Gateway_0h5nxf3" targetRef="timer-ten-seconds" />
     <bpmn:exclusiveGateway id="Gateway_0rsc9zf" default="Flow_1t5mjg2">
       <bpmn:incoming>Flow_1ggxjdm</bpmn:incoming>
@@ -63,49 +63,61 @@
       <bpmn:incoming>Flow_0wk7aco</bpmn:incoming>
       <bpmn:outgoing>Flow_1lelmzg</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_16dvxg9" sourceRef="create-api-client-for-cluster-in-camunda-cloud" targetRef="Gateway_0h5nxf3" />
+    <bpmn:serviceTask id="create-api-client-for-cluster-in-camunda-cloud" name="Create Api Client for Cluster in Camunda Cloud">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="create-api-client-for-cluster-in-camunda-cloud" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0f4lf0m</bpmn:incoming>
+      <bpmn:outgoing>Flow_16dvxg9</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="prepare-zeebe-cluster-in-camunda-cloud">
       <bpmndi:BPMNEdge id="Flow_1lelmzg_di" bpmnElement="Flow_1lelmzg">
-        <di:waypoint x="1180" y="117" />
-        <di:waypoint x="1252" y="117" />
+        <di:waypoint x="1310" y="117" />
+        <di:waypoint x="1382" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wk7aco_di" bpmnElement="Flow_0wk7aco">
-        <di:waypoint x="1020" y="117" />
-        <di:waypoint x="1080" y="117" />
+        <di:waypoint x="1150" y="117" />
+        <di:waypoint x="1210" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0krlig2_di" bpmnElement="condition-healthy">
-        <di:waypoint x="805" y="117" />
-        <di:waypoint x="920" y="117" />
+        <di:waypoint x="935" y="117" />
+        <di:waypoint x="1050" y="117" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="844" y="99" width="38" height="14" />
+          <dc:Bounds x="974" y="99" width="38" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xvisg0_di" bpmnElement="Flow_0xvisg0">
-        <di:waypoint x="558" y="117" />
-        <di:waypoint x="600" y="117" />
+        <di:waypoint x="688" y="117" />
+        <di:waypoint x="730" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1t5mjg2_di" bpmnElement="Flow_1t5mjg2">
-        <di:waypoint x="780" y="142" />
-        <di:waypoint x="780" y="200" />
-        <di:waypoint x="450" y="200" />
-        <di:waypoint x="450" y="142" />
+        <di:waypoint x="910" y="142" />
+        <di:waypoint x="910" y="200" />
+        <di:waypoint x="580" y="200" />
+        <di:waypoint x="580" y="142" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ggxjdm_di" bpmnElement="Flow_1ggxjdm">
-        <di:waypoint x="700" y="117" />
-        <di:waypoint x="755" y="117" />
+        <di:waypoint x="830" y="117" />
+        <di:waypoint x="885" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nplddv_di" bpmnElement="Flow_1nplddv">
-        <di:waypoint x="475" y="117" />
-        <di:waypoint x="522" y="117" />
+        <di:waypoint x="605" y="117" />
+        <di:waypoint x="652" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0f4lf0m_di" bpmnElement="Flow_0f4lf0m">
         <di:waypoint x="370" y="117" />
-        <di:waypoint x="425" y="117" />
+        <di:waypoint x="420" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v89qt6_di" bpmnElement="Flow_0v89qt6">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16dvxg9_di" bpmnElement="Flow_16dvxg9">
+        <di:waypoint x="520" y="117" />
+        <di:waypoint x="555" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
         <dc:Bounds x="179" y="99" width="36" height="36" />
@@ -117,28 +129,31 @@
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0h5nxf3_di" bpmnElement="Gateway_0h5nxf3" isMarkerVisible="true">
-        <dc:Bounds x="425" y="92" width="50" height="50" />
+        <dc:Bounds x="555" y="92" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0rsc9zf_di" bpmnElement="Gateway_0rsc9zf" isMarkerVisible="true">
-        <dc:Bounds x="755" y="92" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ukqd8v_di" bpmnElement="query-zeebe-cluster-state-in-camunda-cloud">
-        <dc:Bounds x="600" y="77" width="100" height="80" />
+        <dc:Bounds x="885" y="92" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_025t7ts_di" bpmnElement="Event_025t7ts">
-        <dc:Bounds x="1252" y="99" width="36" height="36" />
+        <dc:Bounds x="1382" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1si8upl_di" bpmnElement="timer-ten-seconds">
-        <dc:Bounds x="522" y="99" width="36" height="36" />
+        <dc:Bounds x="652" y="99" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="531" y="142" width="19" height="14" />
+          <dc:Bounds x="662" y="142" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1w3gv94_di" bpmnElement="gather-information-about-cluster-in-camunda-cloud">
-        <dc:Bounds x="920" y="77" width="100" height="80" />
+        <dc:Bounds x="1050" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00qa5g7_di" bpmnElement="warm-up-cluster">
-        <dc:Bounds x="1080" y="77" width="100" height="80" />
+        <dc:Bounds x="1210" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1owpdj3_di" bpmnElement="create-api-client-for-cluster-in-camunda-cloud">
+        <dc:Bounds x="420" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ukqd8v_di" bpmnElement="query-zeebe-cluster-state-in-camunda-cloud">
+        <dc:Bounds x="730" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/processes/run-test-in-camunda-cloud.bpmn
+++ b/processes/run-test-in-camunda-cloud.bpmn
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1r7i4vf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1r7i4vf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
   <bpmn:process id="run-test-in-camunda-cloud" name="Run Test in Camunda Cloud" isExecutable="true">
     <bpmn:startEvent id="start" name="Start">
-      <bpmn:outgoing>Flow_0u0o693</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0xldrw7</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0u0o693" sourceRef="start" targetRef="prepare-zeebe-cluster-in-camunda-cloud" />
-    <bpmn:sequenceFlow id="Flow_15k26ho" sourceRef="prepare-zeebe-cluster-in-camunda-cloud" targetRef="Activity_17f0cpn" />
     <bpmn:exclusiveGateway id="check_test_result" name="test result?">
       <bpmn:incoming>Flow_077bhk3</bpmn:incoming>
       <bpmn:outgoing>test_failed</bpmn:outgoing>
@@ -45,27 +43,11 @@
       <bpmn:incoming>Flow_1lecns9</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1cth1vv" sourceRef="destroy-zeebe-cluster-in-camunda-cloud" targetRef="Gateway_0zjsm6e" />
-    <bpmn:callActivity id="prepare-zeebe-cluster-in-camunda-cloud" name="Prepare Zeebe Cluster in Camunda Cloud">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="create-zeebe-cluster-in-camunda-cloud-job" />
-        <zeebe:calledElement processId="prepare-zeebe-cluster-in-camunda-cloud" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0u0o693</bpmn:incoming>
-      <bpmn:outgoing>Flow_15k26ho</bpmn:outgoing>
-    </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_13kuq36" sourceRef="Activity_17f0cpn" targetRef="Activity_1hxzgjq" />
-    <bpmn:callActivity id="Activity_17f0cpn" name="Run Test">
-      <bpmn:extensionElements>
-        <zeebe:calledElement processId="=testProcessId" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_15k26ho</bpmn:incoming>
-      <bpmn:outgoing>Flow_13kuq36</bpmn:outgoing>
-    </bpmn:callActivity>
     <bpmn:serviceTask id="Activity_1hxzgjq" name="Record Test Result">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="record-test-result-job" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_13kuq36</bpmn:incoming>
+      <bpmn:incoming>Flow_0yb3pap</bpmn:incoming>
       <bpmn:outgoing>Flow_077bhk3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_077bhk3" sourceRef="Activity_1hxzgjq" targetRef="check_test_result" />
@@ -79,106 +61,125 @@
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1lecns9" sourceRef="Gateway_0zjsm6e" targetRef="Event_1i1rnvk" />
     <bpmn:sequenceFlow id="Flow_0wlh9er" sourceRef="trigger-analyse-cluster-process" targetRef="Gateway_0zjsm6e" />
+    <bpmn:callActivity id="prepare-zeebe-cluster-in-camunda-cloud" name="Prepare Zeebe Cluster in Camunda Cloud">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="create-zeebe-cluster-in-camunda-cloud-job" />
+        <zeebe:calledElement processId="prepare-zeebe-cluster-in-camunda-cloud" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0xldrw7</bpmn:incoming>
+      <bpmn:outgoing>Flow_15k26ho</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Activity_17f0cpn" name="Run Test">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="=testProcessId" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_15k26ho</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yb3pap</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_15k26ho" sourceRef="prepare-zeebe-cluster-in-camunda-cloud" targetRef="Activity_17f0cpn" />
+    <bpmn:sequenceFlow id="Flow_0yb3pap" sourceRef="Activity_17f0cpn" targetRef="Activity_1hxzgjq" />
+    <bpmn:sequenceFlow id="Flow_0xldrw7" sourceRef="start" targetRef="prepare-zeebe-cluster-in-camunda-cloud" />
   </bpmn:process>
   <bpmn:message id="msg-analysis-completed" name="Analysis Completed">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=clusterId" />
     </bpmn:extensionElements>
   </bpmn:message>
+  <bpmn:error id="Error_09qa8g7" name="Create Cluster Failed" errorCode="failed-create-cluster" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="run-test-in-camunda-cloud">
+      <bpmndi:BPMNEdge id="Flow_0wlh9er_di" bpmnElement="Flow_0wlh9er">
+        <di:waypoint x="900" y="300" />
+        <di:waypoint x="1100" y="300" />
+        <di:waypoint x="1100" y="195" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lecns9_di" bpmnElement="Flow_1lecns9">
+        <di:waypoint x="1125" y="170" />
+        <di:waypoint x="1172" y="170" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mgszoj_di" bpmnElement="test_skipped">
-        <di:waypoint x="790" y="145" />
-        <di:waypoint x="790" y="80" />
-        <di:waypoint x="950" y="80" />
-        <di:waypoint x="950" y="145" />
+        <di:waypoint x="690" y="145" />
+        <di:waypoint x="690" y="80" />
+        <di:waypoint x="850" y="80" />
+        <di:waypoint x="850" y="145" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="813" y="83" width="48" height="14" />
+          <dc:Bounds x="713" y="83" width="48" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_077bhk3_di" bpmnElement="Flow_077bhk3">
-        <di:waypoint x="660" y="170" />
-        <di:waypoint x="765" y="170" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13kuq36_di" bpmnElement="Flow_13kuq36">
-        <di:waypoint x="510" y="170" />
-        <di:waypoint x="560" y="170" />
+        <di:waypoint x="600" y="170" />
+        <di:waypoint x="665" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1cth1vv_di" bpmnElement="Flow_1cth1vv">
-        <di:waypoint x="1130" y="170" />
-        <di:waypoint x="1175" y="170" />
+        <di:waypoint x="1030" y="170" />
+        <di:waypoint x="1075" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1e7iazb_di" bpmnElement="Flow_1e7iazb">
-        <di:waypoint x="975" y="170" />
-        <di:waypoint x="1030" y="170" />
+        <di:waypoint x="875" y="170" />
+        <di:waypoint x="930" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1j2fhvr_di" bpmnElement="test_passed">
-        <di:waypoint x="815" y="170" />
-        <di:waypoint x="925" y="170" />
+        <di:waypoint x="715" y="170" />
+        <di:waypoint x="825" y="170" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="828" y="173" width="44" height="14" />
+          <dc:Bounds x="728" y="173" width="44" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1g2ygbd_di" bpmnElement="test_failed">
-        <di:waypoint x="790" y="195" />
-        <di:waypoint x="790" y="300" />
-        <di:waypoint x="900" y="300" />
+        <di:waypoint x="690" y="195" />
+        <di:waypoint x="690" y="300" />
+        <di:waypoint x="800" y="300" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="818" y="303" width="38" height="14" />
+          <dc:Bounds x="718" y="283" width="38" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15k26ho_di" bpmnElement="Flow_15k26ho">
-        <di:waypoint x="340" y="170" />
-        <di:waypoint x="410" y="170" />
+        <di:waypoint x="310" y="170" />
+        <di:waypoint x="350" y="170" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0u0o693_di" bpmnElement="Flow_0u0o693">
-        <di:waypoint x="188" y="170" />
-        <di:waypoint x="240" y="170" />
+      <bpmndi:BPMNEdge id="Flow_0yb3pap_di" bpmnElement="Flow_0yb3pap">
+        <di:waypoint x="450" y="170" />
+        <di:waypoint x="500" y="170" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lecns9_di" bpmnElement="Flow_1lecns9">
-        <di:waypoint x="1225" y="170" />
-        <di:waypoint x="1272" y="170" />
+      <bpmndi:BPMNEdge id="Flow_0xldrw7_di" bpmnElement="Flow_0xldrw7">
+        <di:waypoint x="148" y="170" />
+        <di:waypoint x="210" y="170" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0wlh9er_di" bpmnElement="Flow_0wlh9er">
-        <di:waypoint x="1000" y="300" />
-        <di:waypoint x="1200" y="300" />
-        <di:waypoint x="1200" y="195" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
-        <dc:Bounds x="152" y="152" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="159" y="195" width="25" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_1hxzgjq_di" bpmnElement="Activity_1hxzgjq">
+        <dc:Bounds x="500" y="130" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0eoa092_di" bpmnElement="check_test_result" isMarkerVisible="true">
-        <dc:Bounds x="765" y="145" width="50" height="50" />
+        <dc:Bounds x="665" y="145" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="713" y="133" width="53" height="14" />
+          <dc:Bounds x="613" y="133" width="54" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1hh2a2j_di" bpmnElement="prepare-zeebe-cluster-in-camunda-cloud">
-        <dc:Bounds x="240" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1a336zp_di" bpmnElement="Activity_17f0cpn">
-        <dc:Bounds x="410" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1hxzgjq_di" bpmnElement="Activity_1hxzgjq">
-        <dc:Bounds x="560" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1w6lwgr_di" bpmnElement="trigger-analyse-cluster-process">
-        <dc:Bounds x="900" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0n2c5zt_di" bpmnElement="Gateway_0n2c5zt" isMarkerVisible="true">
-        <dc:Bounds x="925" y="145" width="50" height="50" />
+        <dc:Bounds x="825" y="145" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09c5z6r_di" bpmnElement="destroy-zeebe-cluster-in-camunda-cloud">
-        <dc:Bounds x="1030" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0zjsm6e_di" bpmnElement="Gateway_0zjsm6e" isMarkerVisible="true">
-        <dc:Bounds x="1175" y="145" width="50" height="50" />
+        <dc:Bounds x="930" y="130" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1i1rnvk_di" bpmnElement="Event_1i1rnvk">
-        <dc:Bounds x="1272" y="152" width="36" height="36" />
+        <dc:Bounds x="1172" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zjsm6e_di" bpmnElement="Gateway_0zjsm6e" isMarkerVisible="true">
+        <dc:Bounds x="1075" y="145" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w6lwgr_di" bpmnElement="trigger-analyse-cluster-process">
+        <dc:Bounds x="800" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hh2a2j_di" bpmnElement="prepare-zeebe-cluster-in-camunda-cloud">
+        <dc:Bounds x="210" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1a336zp_di" bpmnElement="Activity_17f0cpn">
+        <dc:Bounds x="350" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="112" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="120" y="195" width="24" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Adds a workaround to the missing region in the zeebe address url.

It splits the client creation from the cluster creation. This means the cluster is not deleted everytime something goes wrong in the client creation part. 

It also adds a short delay between the client creation and the connection info retrieval, so that console has time to be updated.

The workaround can be removed when camunda-cloud/console#2225 is resolved