### PR TITLE
chore(ci): disable deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
         stage('Deploy') {
             when {
                 anyOf {
-                    branch 'stable/0.26'
+                   // branch 'stable/0.26'
                     expression { params.DEPLOY_TO_DEV }
                 }
             }


### PR DESCRIPTION
We want to disable the 0.26 testbench auto deployment as this version is no longer
supported. This commit disables the branch name deploy trigger in order
to avoid any accidental redeployments. Manual deployments are still possible

related to #423 