### PR TITLE
fix(chaos): avoid getting stuck on run command

### DIFF
--- a/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/core/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -221,11 +221,13 @@ fun prepareForChaosExperiments(namespace: String) {
 
 fun runCommands(workingDir: File?, vararg commands: String): Int {
     val processBuilder = ProcessBuilder(commands.asList())
+        .redirectErrorStream(true)
+
     workingDir?.let {
         processBuilder.directory(workingDir)
     }
     val process = processBuilder.start()
-    process.waitFor()
+    process.waitFor(5, TimeUnit.MINUTES)
     LOG.info(
         "Run ${commands.contentToString()} \n {} {}",
         String(process.inputStream.readAllBytes()),


### PR DESCRIPTION
* redirecting the error stream to avoid getting stuck if it is written to the error stream
* setting a timeout to make it more visible if the process is stuck