### PR TITLE
Enable dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+  - package-ecosysten: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
This should configure dependabot to keep track of updates for github actions. Currently, that is only the backport-action.