### PR TITLE
ci: bump chaos worker version

### DIFF
--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -9,7 +9,7 @@ then
 fi
 
 tag=$1
-workerVersion=1.0.0
+workerVersion=1.1.0
 
 if [[ ${tag} == *-dev ]]; then
   echo "Deploying :dev to 'dev' stage / using '-dev' suffixed files"


### PR DESCRIPTION
Key feature: Everything is bundled in the image and jar, which means we can now change zeebe-chaos master without causing issues.