### PR TITLE
ci: adjust client id's for Testbench Prod

### DIFF
--- a/core/chaos-workers/deployment/chaosWorker-prod.yaml
+++ b/core/chaos-workers/deployment/chaosWorker-prod.yaml
@@ -26,7 +26,7 @@ spec:
             - name: TESTBENCH_AUTHORIZATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
             - name: TESTBENCH_CLIENT_ID
-              value: "6WIMz9KT7076gBWmfV7QJK0zGNotmF04"
+              value: "S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo"
             - name: TESTBENCH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/testbench-prod.yaml
+++ b/testbench-prod.yaml
@@ -22,7 +22,7 @@ spec:
             - name: ZCTB_AUTHENTICATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
             - name: ZCTB_CLIENT_ID
-              value: "6WIMz9KT7076gBWmfV7QJK0zGNotmF04"
+              value: "S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo"
             - name: ZCTB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -40,7 +40,7 @@ spec:
             - name: ZCTB_CLOUD_AUTHENTICATION_SERVER_URL
               value: "https://login.cloud.ultrawombat.com/oauth/token"
             - name: ZCTB_CLOUD_CLIENT_ID
-              value: "CW_I50Di-STzDE2i"
+              value: "oMgf5fM6MKLLhrAU"
             - name: ZCTB_CLOUD_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
I created a new cluster in our `Just testbench` org, a new Zeebe cluster api client and a new cluster api client. I updated the keys in Vault and this PR will update the client id's


related to https://github.com/zeebe-io/zeebe-cluster-testbench/issues/533