### PR TITLE
Maven pom spring cleaning

### DIFF
--- a/cloud-client/pom.xml
+++ b/cloud-client/pom.xml
@@ -17,18 +17,10 @@
   <name>Zeebe Cluster Testbench - Camunda Cloud Client</name>
 
   <dependencies>
-
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
@@ -47,6 +39,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cloud-client/pom.xml
+++ b/cloud-client/pom.xml
@@ -42,11 +42,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>

--- a/cloud-client/pom.xml
+++ b/cloud-client/pom.xml
@@ -25,6 +25,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/cloud-client/pom.xml
+++ b/cloud-client/pom.xml
@@ -10,9 +10,10 @@
     <version>3.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>zeebe-cluster-testbench-cloud-client</artifactId>
 
+  <artifactId>zeebe-cluster-testbench-cloud-client</artifactId>
   <packaging>jar</packaging>
+
   <name>Zeebe Cluster Testbench - Camunda Cloud Client</name>
 
   <dependencies>

--- a/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/CloudAPIClientTest.java
+++ b/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/CloudAPIClientTest.java
@@ -1,8 +1,9 @@
 package io.zeebe.clustertestbench.cloud;
 
+import static io.zeebe.clustertestbench.cloud.JsonAssertions.assertJsonEquality;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.test.util.JsonUtil;
 import io.zeebe.clustertestbench.cloud.CloudAPIClient.CreateClusterRequest;
 import io.zeebe.clustertestbench.cloud.CloudAPIClient.CreateZeebeClientRequest;
 import org.junit.jupiter.api.Test;
@@ -22,17 +23,17 @@ class CloudAPIClientTest {
     final var jsonRepresentation = objectMapper.writeValueAsString(request);
 
     // then
-    JsonUtil.assertEquality(
+    assertJsonEquality(
         jsonRepresentation,
         """
-             {
-                "name": "nameValue",
-                "planTypeId":"planTypeIdValue",
-                "channelId":"channelIdValue",
-                "generationId":"generationIdValue",
-                "regionId":"regionIdValue"
-             }
-            """);
+         {
+            "name": "nameValue",
+            "planTypeId":"planTypeIdValue",
+            "channelId":"channelIdValue",
+            "generationId":"generationIdValue",
+            "regionId":"regionIdValue"
+         }
+        """);
   }
 
   @Test
@@ -46,13 +47,13 @@ class CloudAPIClientTest {
     final var jsonRepresentation = objectMapper.writeValueAsString(request);
 
     // then
-    JsonUtil.assertEquality(
+    assertJsonEquality(
         jsonRepresentation,
         """
-                {
-                   "clientName":"clientNameValue",
-                   "permissions":["zeebe"]
-                }
-              """);
+          {
+             "clientName":"clientNameValue",
+             "permissions":["zeebe"]
+          }
+        """);
   }
 }

--- a/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/JsonAssertions.java
+++ b/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/JsonAssertions.java
@@ -1,0 +1,20 @@
+package io.zeebe.clustertestbench.cloud;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+
+public class JsonAssertions {
+
+  public static void assertJsonEquality(final String actual, final String expected) {
+    final var objectMapper = new ObjectMapper();
+    try {
+      Assertions.assertThat(objectMapper.readTree(actual))
+          .isEqualTo(objectMapper.readTree(expected));
+    } catch (final JsonProcessingException e) {
+      Assertions.fail(
+          "Expected valid JSON, but 'actual' was '%s' and 'expected' was '%s'"
+              .formatted(actual, expected));
+    }
+  }
+}

--- a/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/oauth/OAuthClientTest.java
+++ b/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/oauth/OAuthClientTest.java
@@ -7,13 +7,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static io.zeebe.clustertestbench.cloud.JsonAssertions.assertJsonEquality;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import io.camunda.zeebe.test.util.JsonUtil;
 import io.zeebe.clustertestbench.cloud.oauth.OAuthClient.OAuthCredentials;
 import io.zeebe.clustertestbench.cloud.oauth.OAuthClient.ServiceAccountTokenRequest;
 import io.zeebe.clustertestbench.cloud.oauth.OAuthClient.UserAccountTokenRequest;
@@ -38,7 +38,7 @@ class OAuthClientTest {
     final var jsonRepresentation = objectMapper.writeValueAsString(request);
 
     // then
-    JsonUtil.assertEquality(
+    assertJsonEquality(
         jsonRepresentation,
         """
         {
@@ -63,7 +63,7 @@ class OAuthClientTest {
     final var jsonRepresentation = objectMapper.writeValueAsString(request);
 
     // then
-    JsonUtil.assertEquality(
+    assertJsonEquality(
         jsonRepresentation,
         """
              {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,22 +30,18 @@
     </dependency>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-cluster-testbench-internal-cloud-client</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zeebe</groupId>
       <artifactId>zeebe-cluster-testbench-testdriver-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-cluster-testbench-testdriver-sequential</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
@@ -59,15 +55,26 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.vavr</groupId>
       <artifactId>vavr</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-cluster-testbench-internal-cloud-client</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-worker-java-testutils</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -80,21 +87,14 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-worker-java-testutils</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Zeebe Cluster Testbench - Core</name>
 
-  <properties>
-    <plugin.version.assembly>3.3.0</plugin.version.assembly>
-    <version.slack-api>1.27.2</version.slack-api>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
@@ -49,7 +44,6 @@
     <dependency>
       <groupId>com.slack.api</groupId>
       <artifactId>slack-api-client</artifactId>
-      <version>${version.slack-api}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,10 +59,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>io.vavr</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,10 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.slack.api</groupId>
       <artifactId>slack-api-client</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,8 +16,6 @@
 
   <properties>
     <plugin.version.assembly>3.3.0</plugin.version.assembly>
-    <version.jaxrs>3.0.12.Final</version.jaxrs>
-
     <version.slack-api>1.27.2</version.slack-api>
   </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-process-test-extension</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -16,7 +16,6 @@
   <name>Zeebe Cluster Testbench - Integration Tests</name>
 
   <properties>
-    <bpmn-spec.version>2.0.1</bpmn-spec.version>
     <plugin.version.failsafe>3.0.0-M7</plugin.version.failsafe>
   </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>3.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>zeebe-cluster-testbench-integration-tests</artifactId>
 
+  <artifactId>zeebe-cluster-testbench-integration-tests</artifactId>
   <packaging>jar</packaging>
 
   <name>Zeebe Cluster Testbench - Integration Tests</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,26 +26,24 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-process-test-extension</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-process-test-extension</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -15,10 +15,6 @@
 
   <name>Zeebe Cluster Testbench - Integration Tests</name>
 
-  <properties>
-    <plugin.version.failsafe>3.0.0-M7</plugin.version.failsafe>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
@@ -51,8 +47,8 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.version.failsafe}</version>
         <executions>
           <execution>
             <goals>

--- a/internal-cloud-client/pom.xml
+++ b/internal-cloud-client/pom.xml
@@ -9,13 +9,13 @@
     <version>3.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
+
   <artifactId>zeebe-cluster-testbench-internal-cloud-client</artifactId>
+  <packaging>jar</packaging>
+
   <!-- Note that this project implements a client for internal Camunda Cloud
     services. These internal services are not officially supported and subject
     to change without notice. It is strongly discouraged to depend on this project. -->
-
-  <packaging>jar</packaging>
-
   <name>Zeebe Cluster Testbench - Internal Camunda Cloud Client</name>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -112,18 +112,10 @@
       <!-- zeebe-related -->
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-client-java</artifactId>
+        <artifactId>zeebe-bom</artifactId>
         <version>${zeebe.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-test-util</artifactId>
-        <version>${zeebe.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-util</artifactId>
-        <version>${zeebe.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.zeebe</groupId>
@@ -205,11 +197,6 @@
         <version>${version.commons-io}</version>
       </dependency>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${version.commons-io}</version>
-      </dependency>
-      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${version.junit}</version>
@@ -230,11 +217,6 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${version.awaitility}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <version>${version.wiremock}</version>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,19 +163,11 @@
         <version>${version.log4j}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,9 @@
   <properties>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
+    <plugin.version.assembly>3.3.0</plugin.version.assembly>
     <plugin.version.dependency>3.4.0</plugin.version.dependency>
+    <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
     <plugin.version.flakytestextractor>2.1.1</plugin.version.flakytestextractor>
     <plugin.version.flatten>1.3.0</plugin.version.flatten>
     <plugin.version.fmt>2.13</plugin.version.fmt>
@@ -57,6 +59,7 @@
     <version.awaitility>4.2.0</version.awaitility>
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-text>1.10.0</version.commons-text>
+    <version.grpc-api>1.51.1</version.grpc-api>
     <version.jackson>2.14.1</version.jackson>
     <version.java>17</version.java>
     <version.junit>5.9.1</version.junit>
@@ -64,6 +67,7 @@
     <version.log4j-maven-shade-plugin-extensions>2.19.0</version.log4j-maven-shade-plugin-extensions>
     <version.mockito>4.10.0</version.mockito>
     <version.resteasy>6.2.2.Final</version.resteasy>
+    <version.slack-api>1.20.1</version.slack-api>
     <version.slf4j>2.0.6</version.slf4j>
     <version.vavr>0.10.4</version.vavr>
     <version.wiremock>2.35.0</version.wiremock>
@@ -176,6 +180,11 @@
         <version>${version.jackson}</version>
       </dependency>
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-api</artifactId>
+        <version>${version.grpc-api}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-client</artifactId>
         <version>${version.resteasy}</version>
@@ -184,6 +193,11 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jackson2-provider</artifactId>
         <version>${version.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.slack.api</groupId>
+        <artifactId>slack-api-client</artifactId>
+        <version>${version.slack-api}</version>
       </dependency>
       <dependency>
         <groupId>io.vavr</groupId>
@@ -298,6 +312,11 @@
               <phase>process-sources</phase>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${plugin.version.failsafe}</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,11 @@
         <version>${version.commons-io}</version>
       </dependency>
       <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${version.commons-io}</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${version.junit}</version>
@@ -235,6 +240,11 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${version.awaitility}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8</artifactId>
+        <version>${version.wiremock}</version>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
@@ -293,7 +303,43 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${plugin.version.failsafe}</version>
         </plugin>
-
+        <plugin>
+          <groupId>eu.stamp-project</groupId>
+          <artifactId>pitmp-maven-plugin</artifactId>
+          <version>${plugin.version.pitest}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.pitest</groupId>
+              <artifactId>pitest-junit5-plugin</artifactId>
+              <version>${plugin.version.pitest-junit5}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>io.zeebe</groupId>
+          <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+          <version>${plugin.version.flakytestextractor}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${plugin.version.dependency}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${plugin.version.javadoc}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${plugin.version.surefire}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${plugin.version.jacoco}</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
@@ -313,7 +359,6 @@
       <plugin>
         <groupId>eu.stamp-project</groupId>
         <artifactId>pitmp-maven-plugin</artifactId>
-        <version>${plugin.version.pitest}</version>
         <configuration>
           <mutators>
             <mutator>STRONGER</mutator>
@@ -328,19 +373,11 @@
           </mutators>
           <excludedTestClasses>*IT</excludedTestClasses>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-junit5-plugin</artifactId>
-            <version>${plugin.version.pitest-junit5}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <!-- flaky test extractor plugin -->
       <plugin>
         <groupId>io.zeebe</groupId>
         <artifactId>flaky-test-extractor-maven-plugin</artifactId>
-        <version>${plugin.version.flakytestextractor}</version>
         <executions>
           <execution>
             <goals>
@@ -353,7 +390,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${plugin.version.dependency}</version>
       </plugin>
       <!-- temporarily disabled <plugin> <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId> <version>1.4.1</version> <configuration>
@@ -363,19 +399,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${plugin.version.javadoc}</version>
       </plugin>
       <!-- Surefire plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${plugin.version.surefire}</version>
       </plugin>
       <!-- JaCoCo Plugin -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${plugin.version.jacoco}</version>
         <executions>
           <execution>
             <id>coverage-initialize</id>
@@ -396,7 +429,6 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>${plugin.version.spotless}</version>
         <configuration>
           <!-- Google code format plugin -->
           <java>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
   <properties>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
-    <plugin.version.build-helper>3.2.0</plugin.version.build-helper>
     <plugin.version.dependency>3.4.0</plugin.version.dependency>
     <plugin.version.flakytestextractor>2.1.1</plugin.version.flakytestextractor>
     <plugin.version.flatten>1.3.0</plugin.version.flatten>
@@ -51,7 +50,6 @@
     <plugin.version.maven-shade>3.4.1</plugin.version.maven-shade>
     <plugin.version.pitest>1.3.7</plugin.version.pitest>
     <plugin.version.pitest-junit5>1.1.0</plugin.version.pitest-junit5>
-    <plugin.version.shade>3.2.4</plugin.version.shade>
     <plugin.version.spotless>2.28.0</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M7</plugin.version.surefire>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -64,7 +62,6 @@
     <version.junit>5.9.1</version.junit>
     <version.log4j>2.19.0</version.log4j>
     <version.log4j-maven-shade-plugin-extensions>2.19.0</version.log4j-maven-shade-plugin-extensions>
-    <version.log4j2-cachefile>2.14.1</version.log4j2-cachefile>
     <version.mockito>4.10.0</version.mockito>
     <version.resteasy>6.2.2.Final</version.resteasy>
     <version.slf4j>2.0.6</version.slf4j>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
   </properties>
 
   <dependencyManagement>
+    <!-- internal modules -->
     <dependencies>
       <dependency>
         <groupId>io.zeebe</groupId>
@@ -105,6 +106,8 @@
         <artifactId>zeebe-cluster-testbench-testdriver-api</artifactId>
         <version>${project.version}</version>
       </dependency>
+
+      <!-- zeebe-related -->
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-client-java</artifactId>
@@ -121,6 +124,19 @@
         <artifactId>zeebe-util</artifactId>
         <version>${zeebe.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zeebe-worker-java-testutils</artifactId>
+        <version>${version.zeebeWorkerJavaTestutils}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-process-test-extension</artifactId>
+        <version>${version.zeebe-process-test}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Third party dependencies -->
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
@@ -208,17 +224,6 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${version.awaitility}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zeebe</groupId>
-        <artifactId>zeebe-worker-java-testutils</artifactId>
-        <version>${version.zeebeWorkerJavaTestutils}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-process-test-extension</artifactId>
-        <version>${version.zeebe-process-test}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-test-util</artifactId>
         <version>${zeebe.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.camunda</groupId>
@@ -133,7 +132,6 @@
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
         <version>${version.zeebe-process-test}</version>
-        <scope>test</scope>
       </dependency>
 
       <!-- Third party dependencies -->
@@ -192,7 +190,6 @@
         <artifactId>vavr</artifactId>
         <version>${version.vavr}</version>
       </dependency>
-      <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -287,31 +287,6 @@
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${plugin.version.spotless}</version>
-          <configuration>
-            <!-- Google code format plugin -->
-            <java>
-              <googleJavaFormat>
-                <version>${plugin.version.googlejavaformat}</version>
-                <style>GOOGLE</style>
-              </googleJavaFormat>
-            </java>
-            <!-- SortPOM plugin -->
-            <pom>
-              <sortPom>
-                <expandEmptyElements>false</expandEmptyElements>
-                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                <sortProperties>true</sortProperties>
-              </sortPom>
-            </pom>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>apply</goal>
-              </goals>
-              <phase>process-sources</phase>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -423,6 +398,22 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${plugin.version.spotless}</version>
         <configuration>
+          <!-- Google code format plugin -->
+          <java>
+            <googleJavaFormat>
+              <version>${plugin.version.googlejavaformat}</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+          </java>
+          <!-- SortPOM plugin -->
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              <sortProperties>true</sortProperties>
+            </sortPom>
+          </pom>
+          <!-- flexmark-java plugin -->
           <markdown>
             <includes>
               <include>**/*.md</include>

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,6 @@
 
     <plugins>
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>eu.stamp-project</groupId>
         <artifactId>pitmp-maven-plugin</artifactId>
         <version>${plugin.version.pitest}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
   <name>Zeebe Cluster Testbench</name>
   <description>${name}</description>
 
-  <!-- When changing the artifact or name, also make sure to change the SCM
-    location below and in .ci/scripts/github-release.sh -->
   <modules>
     <module>core</module>
     <module>cloud-client</module>
@@ -374,7 +372,6 @@
           <excludedTestClasses>*IT</excludedTestClasses>
         </configuration>
       </plugin>
-      <!-- flaky test extractor plugin -->
       <plugin>
         <groupId>io.zeebe</groupId>
         <artifactId>flaky-test-extractor-maven-plugin</artifactId>
@@ -400,12 +397,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
-      <!-- Surefire plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
-      <!-- JaCoCo Plugin -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -423,7 +418,6 @@
             </goals>
             <phase>post-integration-test</phase>
           </execution>
-          <!-- Threshold -->
         </executions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -233,29 +233,11 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/testdriver/api/pom.xml
+++ b/testdriver/api/pom.xml
@@ -21,6 +21,7 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -38,19 +39,16 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>

--- a/testdriver/api/pom.xml
+++ b/testdriver/api/pom.xml
@@ -10,9 +10,10 @@
     <version>3.0.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  <artifactId>zeebe-cluster-testbench-testdriver-api</artifactId>
 
+  <artifactId>zeebe-cluster-testbench-testdriver-api</artifactId>
   <packaging>jar</packaging>
+
   <name>Zeebe Cluster Testbench - API for Testdrivers</name>
 
   <dependencies>

--- a/testdriver/api/pom.xml
+++ b/testdriver/api/pom.xml
@@ -31,10 +31,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/testdriver/api/src/test/java/io/zeebe/clustertestbench/testdriver/api/JsonAssertions.java
+++ b/testdriver/api/src/test/java/io/zeebe/clustertestbench/testdriver/api/JsonAssertions.java
@@ -1,0 +1,20 @@
+package io.zeebe.clustertestbench.testdriver.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+
+public class JsonAssertions {
+
+  public static void assertJsonEquality(final String actual, final String expected) {
+    final var objectMapper = new ObjectMapper();
+    try {
+      Assertions.assertThat(objectMapper.readTree(actual))
+          .isEqualTo(objectMapper.readTree(expected));
+    } catch (final JsonProcessingException e) {
+      Assertions.fail(
+          "Expected valid JSON, but 'actual' was '%s' and 'expected' was '%s'"
+              .formatted(actual, expected));
+    }
+  }
+}

--- a/testdriver/api/src/test/java/io/zeebe/clustertestbench/testdriver/api/TestReportTest.java
+++ b/testdriver/api/src/test/java/io/zeebe/clustertestbench/testdriver/api/TestReportTest.java
@@ -1,11 +1,11 @@
 package io.zeebe.clustertestbench.testdriver.api;
 
+import static io.zeebe.clustertestbench.testdriver.api.JsonAssertions.assertJsonEquality;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.test.util.JsonUtil;
 import io.zeebe.clustertestbench.testdriver.api.TestDriver.TestReportDTO;
 import io.zeebe.clustertestbench.testdriver.api.TestDriver.TestResult;
 import org.assertj.core.api.Assertions;
@@ -49,7 +49,7 @@ public class TestReportTest {
     final var jsonRepresentation = OBJECT_MAPPER.writeValueAsString(testReport);
 
     // then
-    JsonUtil.assertEquality(
+    assertJsonEquality(
         jsonRepresentation,
         """
                 {

--- a/testdriver/sequential/pom.xml
+++ b/testdriver/sequential/pom.xml
@@ -25,13 +25,10 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-cluster-testbench-testdriver-api</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -39,6 +36,10 @@
       <version>${zeebe.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
@@ -60,7 +61,6 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>

--- a/testdriver/sequential/pom.xml
+++ b/testdriver/sequential/pom.xml
@@ -10,9 +10,10 @@
     <version>3.0.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  <artifactId>zeebe-cluster-testbench-testdriver-sequential</artifactId>
 
+  <artifactId>zeebe-cluster-testbench-testdriver-sequential</artifactId>
   <packaging>jar</packaging>
+
   <name>Zeebe Cluster Testbench - Sequential Testdriver</name>
 
   <properties>

--- a/testdriver/sequential/pom.xml
+++ b/testdriver/sequential/pom.xml
@@ -16,10 +16,6 @@
 
   <name>Zeebe Cluster Testbench - Sequential Testdriver</name>
 
-  <properties>
-    <version.grpc-api>1.51.1</version.grpc-api>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
@@ -43,7 +39,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>${version.grpc-api}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This cleans up the pom files:
- improves the readability by applying a consistent style
- moves all version definitions into dependency management and plugin management
- moves all properties into the root project
- organizes dependencies into a few main categories
- ~re-enables the maven enforcer plugin, reduces the strictness from `dependencyConvergence` to `requireUpperBoundDeps`~
- removes unnecessary dependencies on `zeebe-util` and `zeebe-test-util` modules

This pull request had been on hold since it was first opened in March 2022. This was at the time that ZPT hadn't been officially released yet, and this project depended on a SNAPSHOT version of it. Dependency convergence between ZPT and the Zeebe Client was a major reason that I was unable to re-enable the maven enforcer plugin. I'm not sure that we should block this pull request from being merged any longer for that reason. If we want to re-enable the maven enforcer plugin, then we also do that in a separate pull request.