### PR TITLE
Fix jakarta.ws.rs.ext.Providers file in shaded jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -124,6 +124,9 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>io.zeebe.clustertestbench.bootstrap.BootstrapFromEnvVars</mainClass>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/jakarta.ws.rs.ext.Providers</resource>
+                </transformer>
               </transformers>
               <finalName>zeebe-cluster-testbench-uber-jar-with-dependencies</finalName>
             </configuration>


### PR DESCRIPTION
The Providers file located in META-INF/services is supposed to define
the available provider classes. This is where it will look for the
writers. It seemed that the shade plugin somehow merged these files
differently. By defining an appending strategy the file should contain
all entries.

This was an idea from: https://stackoverflow.com/a/18538803/3442860

Note that we use newer version that is not in the javax.ws.rs but in
jakarta.ws.rs namespace.

closes #608 