### PR TITLE
feat: flatten all POMs for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ config.properties
 /secrets-dev.yaml
 **/.checkstyle
 **/.factorypath
+
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   <packaging>pom</packaging>
 
   <name>Zeebe Cluster Testbench</name>
+  <description>${name}</description>
 
   <!-- When changing the artifact or name, also make sure to change the SCM
     location below and in .ci/scripts/github-release.sh -->
@@ -42,6 +43,7 @@
     <plugin.version.build-helper>3.2.0</plugin.version.build-helper>
     <plugin.version.dependency>3.3.0</plugin.version.dependency>
     <plugin.version.flakytestextractor>2.1.1</plugin.version.flakytestextractor>
+    <plugin.version.flatten>1.2.7</plugin.version.flatten>
     <plugin.version.fmt>2.13</plugin.version.fmt>
     <plugin.version.googlejavaformat>1.12.0</plugin.version.googlejavaformat>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
@@ -436,6 +438,39 @@
               <goal>apply</goal>
             </goals>
             <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${plugin.version.flatten}</version>
+        <configuration>
+          <flattenMode>ossrh</flattenMode>
+          <!--
+            do not change the outputDirectory; it must remain the same one as the relative project
+            directory, as many plugins expect to resolve the project directory from the current POM
+            file's parent, and any plugin which would run post flatten would resolve the project
+            directory to the wrong one. For example, if you configure it to
+            ${project.build.directory}, then any plugin after will think that the project's
+            directory is not /parent/ but /parent/target, which may affect the execution of plugins
+            (e.g. resource file resolution)
+            -->
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>clean</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Introduces the `flatten-maven-plugin` in the build process. The projects are flattened according to the `ossrh` rules.

I took a shortcut with the description, by setting it to the name of the module. Before we didn't have any descriptions at all and this would take preference over the description that we would otherwise inherit from the `camunda-release-parent` pom.

closes #580 