### PR TITLE
Log4j maven shade plugin extension

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -120,7 +120,7 @@
             <configuration>
               <transformers>
                 <!-- We need this to overcome https://issues.apache.org/jira/browse/LOG4J2-673 -->
-                <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+                <transformer implementation="io.github.edwgiz.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>io.zeebe.clustertestbench.bootstrap.BootstrapFromEnvVars</mainClass>
                 </transformer>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.junit>5.8.2</version.junit>
     <version.log4j>2.17.2</version.log4j>
     <version.log4j2-cachefile>2.14.1</version.log4j2-cachefile>
-    <version.log4j2-cachefile-transformer>2.8.1</version.log4j2-cachefile-transformer>
+    <version.log4j2-cachefile-transformer>2.15</version.log4j2-cachefile-transformer>
     <version.mockito>4.4.0</version.mockito>
     <version.resteasy>6.0.0.Final</version.resteasy>
     <version.slf4j>1.7.36</version.slf4j>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
     <version.java>17</version.java>
     <version.junit>5.8.2</version.junit>
     <version.log4j>2.17.2</version.log4j>
+    <version.log4j-maven-shade-plugin-extensions>2.17.1</version.log4j-maven-shade-plugin-extensions>
     <version.log4j2-cachefile>2.14.1</version.log4j2-cachefile>
-    <version.log4j2-cachefile-transformer>2.15</version.log4j2-cachefile-transformer>
     <version.mockito>4.4.0</version.mockito>
     <version.resteasy>6.0.0.Final</version.resteasy>
     <version.slf4j>1.7.36</version.slf4j>
@@ -317,9 +317,9 @@
           <version>${plugin.version.maven-shade}</version>
           <dependencies>
             <dependency>
-              <groupId>com.github.edwgiz</groupId>
-              <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-              <version>${version.log4j2-cachefile-transformer}</version>
+              <groupId>io.github.edwgiz</groupId>
+              <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
+              <version>${version.log4j-maven-shade-plugin-extensions}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Fix for the failing PR by dependabot #606 

The dependency we use here has been replaced with a different group and artifact id. Making sure we stay up to date I have changed them and switched to the latest version.

Logging still works fine as can be seen here: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22zeebe-io%22%0Aresource.labels.location%3D%22europe-west1-b%22%0Aresource.labels.cluster_name%3D%22zeebe-cluster%22%0Aresource.labels.namespace_name%3D%22testbench-1-x-dev%22%0Alabels.k8s-pod%2Fapp%3D%22testbench%22%0A%0A;timeRange=2022-03-25T08:28:15.834Z%2F2022-03-25T09:18:15.834448Z;cursorTimestamp=2022-03-25T08:49:46.584Z?project=zeebe-io

The jsonPayload gets added and filled with the correct fields.