### PR TITLE
ci: open java modules for nexus-staging-maven-plugin

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -3,3 +3,7 @@
 --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.text=ALL-UNNAMED
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED


### PR DESCRIPTION
Copy and paste of https://github.com/camunda/zeebe/pull/8130 

> Adding add-opens is a workaround for [OSSRH-66257](https://issues.sonatype.org/browse/OSSRH-66257) and [NEXUS-26993](https://issues.sonatype.org/browse/NEXUS-26993). Because we don't control the plugin ourselves and instead inherit it from camunda-release-parent we can't just add a dependency overwrite
as suggested in [OSSRH-66257](https://issues.sonatype.org/browse/OSSRH-66257).