### PR TITLE
chore: use log level debug by default

### DIFF
--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -17,9 +17,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.zeebe.clustertestbench.cloud.filter" level="info" additivity="false"/>
-    <Logger name="io.zeebe.clustertestbench" level="info"/>
-    <Logger name="io.zeebe" level="info"/>
+    <Logger name="io.zeebe" level="debug"/>
 
     <Root level="info">
       <AppenderRef ref="${env:ZCTB_LOG_APPENDER:-Console}"/>


### PR DESCRIPTION
Previously, log level was filtered to INFO or higher. This was when
we looked at the log in K8S console and the debug logs were very verbose.

Recently, we switched to stackdriver logs. With stackdriver logs looking
at the logs in console is no longer convenient. Instead, we now use StackDriver
which also gives us the option to filter on the log level.