### PR TITLE
Allow multiple concurrent invocations

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/handler/TriggerMessageStartEventHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/TriggerMessageStartEventHandler.java
@@ -46,7 +46,7 @@ public class TriggerMessageStartEventHandler implements JobHandler {
     zeebeClient
         .newPublishMessageCommand()
         .messageName(messageName)
-        .correlationKey("correlationKey")
+        .correlationKey("")
         .variables(variables)
         .send()
         .join();

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/TriggerMessageStartEventHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/TriggerMessageStartEventHandlerTest.java
@@ -121,14 +121,14 @@ class TriggerMessageStartEventHandlerTest {
     sutHandler.handle(jobClientStub, activatedJobStub);
 
     // then
-    verify(mockPublishMessageCommandStep2).correlationKey(null);
+    verify(mockPublishMessageCommandStep2).correlationKey("");
   }
 
   private void setupMocksForPublishMessageCommand() {
     when(mockZeebeClient.newPublishMessageCommand()).thenReturn(mockPublishMessageCommandStep1);
     when(mockPublishMessageCommandStep1.messageName(Mockito.anyString()))
         .thenReturn(mockPublishMessageCommandStep2);
-    when(mockPublishMessageCommandStep2.correlationKey(Mockito.isNull()))
+    when(mockPublishMessageCommandStep2.correlationKey(Mockito.anyString()))
         .thenReturn(mockPublishMessageCommandStep3);
     when(mockPublishMessageCommandStep3.variables(Mockito.anyString()))
         .thenReturn(mockPublishMessageCommandStep3);


### PR DESCRIPTION
Allows multiple concurrent invocations of the triggered process by using an empty correlation key.

closes #630 