### PR TITLE
chore(ci): adjust direct Vault usage in Jenkins to new path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,5 +235,5 @@ def getTag() {
 }
 
 def getSecretStore() {
-    return params.DEPLOY_TO_DEV ? 'secret/common/ci-zeebe/testbench-secrets-1.x-dev' : 'secret/common/ci-zeebe/testbench-secrets-1.x-prod'
+    return params.DEPLOY_TO_DEV ? 'secret/products/zeebe/ci/testbench-secrets-1.x-dev' : 'secret/products/zeebe/ci/testbench-secrets-1.x-prod'
 }

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -48,13 +48,13 @@ All stages are clusters running on the Camunda Cloud int environment (ultrawomba
 
 - Image tag `*-dev`
 - K8S namespace = `gke_zeebe-io_europe-west1-b_zeebe-cluster/testbench-1-x-dev`
-- Secrets `secret/common/ci-zeebe/testbench-secrets-1.x-dev`
+- Secrets `secret/products/zeebe/ci/testbench-secrets-1.x-dev`
 
 ### Prod Stage
 
 - Image tag `*-prod`
 - K8S namespace = `gke_zeebe-io_europe-west1-b_zeebe-cluster/testbench-1-x-prod`
-- Secrets `secret/common/ci-zeebe/testbench-secrets-1.x-prod`
+- Secrets `secret/products/zeebe/ci/testbench-secrets-1.x-prod`
 
 ## Permutation Testing
 


### PR DESCRIPTION
we are restructuring Vault paths to ease the self-service.

See announcement on [slack](https://camunda.slack.com/archives/C03AEFWGJ9K/p1657524606321389).

The secrets have already been copied to the new space and the team was granted permission.