### PR TITLE
deps(maven): bump google-java-format to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <plugin.version.flakytestextractor>2.1.1</plugin.version.flakytestextractor>
     <plugin.version.flatten>1.3.0</plugin.version.flatten>
     <plugin.version.fmt>2.13</plugin.version.fmt>
-    <plugin.version.googlejavaformat>1.12.0</plugin.version.googlejavaformat>
+    <plugin.version.googlejavaformat>1.15.0</plugin.version.googlejavaformat>
     <plugin.version.jacoco>0.8.8</plugin.version.jacoco>
     <plugin.version.javadoc>3.4.1</plugin.version.javadoc>
     <plugin.version.maven-shade>3.4.1</plugin.version.maven-shade>


### PR DESCRIPTION
Bumps the google-java-format plugin used by spotless to 1.15.0.

This should avoid the following error when running `mvn compile`

>[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.28.0:apply (default) on project zeebe-cluster-testbench-core: Execution default of goal com.diffplug.spotless:spotless-maven-plugin:2.28.0:apply failed: java.lang.Exception: You are not using latest version on JVM 11+.
[ERROR] Try to upgrade to google-java-format 1.15.0, which may have fixed this problem.: InvocationTargetException: 'long com.sun.tools.javac.tree.DCTree$DCReference.getSourcePosition(com.sun.tools.javac.tree.DCTree$DCDocComment)'