### PR TITLE
fix(ci): add git safe directory for release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,6 +189,7 @@ pipeline {
                         sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
                         sh 'git config --global user.email "ci@camunda.com"'
                         sh 'git config --global user.name "${GITHUB_TOKEN_USR}"'
+                        sh 'git config --global --add safe.directory "\$PWD"'
                         sh '''
                             mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar \
                               javadoc:jar release:prepare release:perform -Prelease \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
                         sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
                         sh 'git config --global user.email "ci@camunda.com"'
                         sh 'git config --global user.name "${GITHUB_TOKEN_USR}"'
-                        sh 'git config --global --add safe.directory "\$PWD"'
+                        sh 'git config --global --add safe.directory "${PWD}"'
                         sh '''
                             mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar \
                               javadoc:jar release:prepare release:perform -Prelease \


### PR DESCRIPTION
This addresses a new safety check that currently leads to a failing release.

See similar fix to other Jenkins setup [here](https://github.com/camunda/camunda-optimize/commit/8e76b89f3272a1dd5144ed200a84c63ba54c1a19).