### PR TITLE
fix: don't hide incident when QA times out

### DIFF
--- a/workflows/qa-github-trigger.bpmn
+++ b/workflows/qa-github-trigger.bpmn
@@ -58,7 +58,7 @@
       <bpmn:incoming>Flow_1vyp0cy</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1vyp0cy" sourceRef="Activity_0d6h12d" targetRef="Event_0kcubc0" />
-    <bpmn:boundaryEvent id="Event_1p9ayal" attachedToRef="Activity_0gxslr9">
+    <bpmn:boundaryEvent id="Event_1p9ayal" cancelActivity="false" attachedToRef="Activity_0gxslr9">
       <bpmn:outgoing>Flow_032f7m5</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0bb19ml">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT6H</bpmn:timeDuration>


### PR DESCRIPTION
Use a non-interrupting boundary timer event instead of an interrupting one to ensure that incidents in the called process remain visible in Operate.