### PR TITLE
fix: use correct permission string

### DIFF
--- a/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/CloudAPIClient.java
+++ b/cloud-client/src/main/java/io/zeebe/clustertestbench/cloud/CloudAPIClient.java
@@ -75,7 +75,7 @@ public interface CloudAPIClient {
 
   record CreateZeebeClientRequest(String clientName) {
 
-    private static final List<String> PERMISSIONS = Collections.singletonList("zeebe");
+    private static final List<String> PERMISSIONS = Collections.singletonList("Zeebe");
 
     public List<String> getPermissions() {
       return PERMISSIONS;

--- a/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/CloudAPIClientTest.java
+++ b/cloud-client/src/test/java/io/zeebe/clustertestbench/cloud/CloudAPIClientTest.java
@@ -52,7 +52,7 @@ class CloudAPIClientTest {
         """
           {
              "clientName":"clientNameValue",
-             "permissions":["zeebe"]
+             "permissions":["Zeebe"]
           }
         """);
   }


### PR DESCRIPTION
Previously permission were ignored. But now the api expects Zeebe with caps Z.
https://camunda.slack.com/archives/CKZK2E7RP/p1680265285860139?thread_ts=1680264644.312409&cid=CKZK2E7RP 
https://github.com/camunda-cloud/camunda-cloud-management-apps/pull/160 