### PR TITLE
Switch bors config to await github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,3 +150,14 @@ jobs:
         fields: repo,action,eventName,ref,workflow
       env:
         SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.slackWebhookUrl }}
+
+  test-summary:
+    # Used by bors to check all tests, including the unit test matrix.
+    # New test jobs must be added to the `needs` lists!
+    # This name is hard-referenced from bors.toml; remember to update that if this name changes
+    name: Test summary
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - run: exit 0

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  "continuous-integration/jenkins/branch"
+  "Test summary"
 ]
 
 required_approvals = 0


### PR DESCRIPTION
Recently Jenkins has been swapped out for GHA, but it seems Bors' configuration was not considered.
- #583 

This commit applies the same structure used in the Zeebe repo to allow Bors to await a GHA workflow that awaits one or several GHA jobs.