### PR TITLE
Add slack webhook url as environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,7 @@ jobs:
         CONTACT_POINT: ${{ steps.secrets.outputs.contactPoint }}
         INTERNAL_CLOUD_CLIENT_SECRET: ${{ steps.secrets.outputs.internalCloudClientSecret }}
         INTERNAL_CLOUD_PASSWORD: ${{ steps.secrets.outputs.internalCloudPassword }}
+        SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.slackWebhookUrl }}
         # DRY_RUN: 'true'
 
     - name: Send Slack notification


### PR DESCRIPTION
- The `ZCTB_SLACK_WEBHOOK_URL` env var is an empty string
- The var is required, but empty string is accepted
- This env var is filled from a k8s secret, other secrets are correctly filled in
- The k8s secret is also an empty string
- The deploy.sh script is run from build.yml workflow but does not pass in the url as secret (even though the secret is retrieved in the import secrets step)