### PR TITLE
refactor(processes): increase retry delay when querying cluster state

### DIFF
--- a/processes/prepare-zeebe-cluster-in-camunda-cloud.bpmn
+++ b/processes/prepare-zeebe-cluster-in-camunda-cloud.bpmn
@@ -62,11 +62,11 @@
         <bpmn:incoming>Flow_0xvisg0</bpmn:incoming>
         <bpmn:outgoing>Flow_1ggxjdm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:intermediateCatchEvent id="timer-ten-seconds" name="10s">
+      <bpmn:intermediateCatchEvent id="timer-ten-seconds" name="60s">
         <bpmn:incoming>Flow_1nplddv</bpmn:incoming>
         <bpmn:outgoing>Flow_0xvisg0</bpmn:outgoing>
         <bpmn:timerEventDefinition id="TimerEventDefinition_0lqf24y">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT10S</bpmn:timeDuration>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT60S</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_1t5mjg2" sourceRef="Gateway_0rsc9zf" targetRef="Gateway_0h5nxf3" />


### PR DESCRIPTION
The timer to retry "Query Zeebe Cluster State in Camunda Cloud" is increased from 10s to 1 minute.
![image](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/1997478/23bdbd45-eb6d-4b81-a3e9-bad27d3f01d4)

Sometimes we get rate limited by cloud api resulting in incidents and test failures. To reduce the likelihood of hitting 'Too many requests' error we reduce the retry frequency.