### PR TITLE
Handle invalid generations

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
@@ -11,6 +11,10 @@ import io.zeebe.clustertestbench.util.StringLookup;
 import org.apache.commons.lang3.RandomStringUtils;
 
 public class CreateGenerationInCamundaCloudHandler implements JobHandler {
+
+  public static final String ERROR_CODE_ILLEGAL_GENERATION = "IllegalGeneration";
+  public static final String ERROR_MSG_EXPECTED_TO_CLONE_A_GENERATION =
+      "Expected to clone a generation with upgradeableFrom reference, but generation %s has no reference set. This will cause console API to not find the respective generation.";
   private final ExternalConsoleAPIClient consoleApiClient;
 
   public CreateGenerationInCamundaCloudHandler(final ExternalConsoleAPIClient consoleApiClient) {
@@ -23,6 +27,24 @@ public class CreateGenerationInCamundaCloudHandler implements JobHandler {
 
     final var generationName = createGenerationName();
     final var templateGeneration = lookupTemplate(input.getGenerationTemplate());
+
+    if (templateGeneration.upgradeableFrom().isEmpty()) {
+      // This a shortcut until
+      // https://github.com/camunda-cloud/camunda-cloud-management-apps/issues/1731 is fixed
+      // Normally we would expect that we can clone all kind of generations but currently this is
+      // not possible.
+      // If we reference a generation without the upgradeableFrom reference (so no reference)
+      // we retrieve weird errors which are hard to debug.
+      // https://github.com/zeebe-io/zeebe-cluster-testbench/issues/945
+      client
+          .newThrowErrorCommand(job)
+          .errorCode(ERROR_CODE_ILLEGAL_GENERATION)
+          .errorMessage(
+              String.format(ERROR_MSG_EXPECTED_TO_CLONE_A_GENERATION, input.generationTemplate))
+          .send();
+
+      return;
+    }
 
     final var zeebeImage = input.getZeebeImage();
     final var operateImage = input.getOperateImage();

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
@@ -1,6 +1,7 @@
 package io.zeebe.clustertestbench.handler;
 
 import static io.zeebe.clustertestbench.internal.cloud.StubExternalConsoleAPIClient.DEFAULT_GENERATION_NAME;
+import static io.zeebe.clustertestbench.internal.cloud.StubExternalConsoleAPIClient.GENERATION_NAME_WITHOUT_UPGRADE_FROM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -92,6 +93,22 @@ class CreateGenerationInCamundaCloudHandlerTest {
 
       assertThat(request.operateVersion()).isNull();
       assertThat(request.zeebeVersion()).isNull();
+    }
+
+    @Test
+    public void shouldNotCreateGenerationWhenReferencingInvalidGeneration() throws Exception {
+      // given
+      activatedJobStub.setInputVariables(
+          Map.of(FIELD_GENERATION_TEMPLATE, GENERATION_NAME_WITHOUT_UPGRADE_FROM));
+
+      // when
+      sutCreateGenerationHandler.handle(jobClientStub, activatedJobStub);
+
+      // then
+      assertThat(activatedJobStub.hasThrownError()).isTrue();
+      assertThat(activatedJobStub.getErrorMessage())
+          .contains("Expected to clone a generation with upgradeableFrom reference")
+          .contains(GENERATION_NAME_WITHOUT_UPGRADE_FROM);
     }
 
     @Test

--- a/external-console-api-client/src/main/java/io/zeebe/clustertestbench/internal/cloud/ExternalConsoleAPIClient.java
+++ b/external-console-api-client/src/main/java/io/zeebe/clustertestbench/internal/cloud/ExternalConsoleAPIClient.java
@@ -35,5 +35,9 @@ public interface ExternalConsoleAPIClient {
   record CloneGenerationRequest(String name, String zeebeVersion, String operateVersion) {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  record GenerationInfo(String uuid, String name, Map<String, String> versions) {}
+  record GenerationInfo(
+      String uuid,
+      String name,
+      Map<String, String> versions,
+      List<Map<String, String>> upgradeableFrom) {}
 }

--- a/external-console-api-client/src/test/java/io/zeebe/clustertestbench/internal/cloud/StubExternalConsoleAPIClient.java
+++ b/external-console-api-client/src/test/java/io/zeebe/clustertestbench/internal/cloud/StubExternalConsoleAPIClient.java
@@ -12,6 +12,10 @@ public class StubExternalConsoleAPIClient implements ExternalConsoleAPIClient {
 
   public static final String DEFAULT_GENERATION_NAME = "default-generation";
   public static final String DEFAULT_GENERATION_UUID = "1a2b3c4f56789-1234-abcd-1a2b3c4f5678";
+
+  public static final String GENERATION_NAME_WITHOUT_UPGRADE_FROM = "generationWithoutUpgradeFrom";
+  public static final String GENERATION_UUID_WITHOUT_UPGRADE_FROM =
+      "4f4b3c4f56789-1234-abcd-1a2b3c4f5678";
   public static final String DEFAULT_ZEEBE_IMAGE = "camunda/zeebe:0.23.7";
   public static final String DEFAULT_OPERATE_IMAGE = "camunda/operate:0.23.2";
 
@@ -31,9 +35,20 @@ public class StubExternalConsoleAPIClient implements ExternalConsoleAPIClient {
     versions.put(KEY_OPERATE_IMAGE, DEFAULT_OPERATE_IMAGE);
 
     final GenerationInfo generationInfo =
-        new GenerationInfo(DEFAULT_GENERATION_UUID, DEFAULT_GENERATION_NAME, versions);
-
+        new GenerationInfo(
+            DEFAULT_GENERATION_UUID,
+            DEFAULT_GENERATION_NAME,
+            versions,
+            List.of(Map.of("uuid", "fake")));
     generationInfos.add(generationInfo);
+
+    final GenerationInfo generationInfoWithoutUpgradeFrom =
+        new GenerationInfo(
+            GENERATION_UUID_WITHOUT_UPGRADE_FROM,
+            GENERATION_NAME_WITHOUT_UPGRADE_FROM,
+            versions,
+            List.of());
+    generationInfos.add(generationInfoWithoutUpgradeFrom);
   }
 
   @Override
@@ -52,7 +67,8 @@ public class StubExternalConsoleAPIClient implements ExternalConsoleAPIClient {
           new ExternalConsoleAPIClient.GenerationInfo(
               UUID.randomUUID().toString(),
               request.name(),
-              Map.of("zeebe", zeebeVersion, "operate", operateVersion));
+              Map.of("zeebe", zeebeVersion, "operate", operateVersion),
+              List.of(Map.of("uuid", "fake")));
 
       generationInfos.add(generationInfo);
       return generationInfo;


### PR DESCRIPTION
> [!Note]
> This a shortcut fix or workaround until https://github.com/camunda-cloud/camunda-cloud-management-apps/issues/1731 is fixed.

 Normally we would expect that we can clone all kinds of generations but currently, this is not possible. If we reference a generation without the upgradeable from reference (so no reference) we retrieve errors (not found generation) which are hard to debug. See related issue https://github.com/zeebe-io/zeebe-cluster-testbench/issues/945

closes #945 