### PR TITLE
ci: migrate to workload federation

### DIFF
--- a/.ci/scripts/deploy.sh
+++ b/.ci/scripts/deploy.sh
@@ -28,19 +28,6 @@ echo "suffix: ${suffix}"
 namespace="testbench-${tag//\./-}"
 echo "target namespace: ${namespace}"
 
-gcloud config set core/project zeebe-io
-
-set +x; echo "${SA_CREDENTIALS}" > sa-credentials.json; set -x
-
-gcloud auth activate-service-account jenkins-ci-cd@zeebe-io.iam.gserviceaccount.com --key-file=sa-credentials.json
-
-gcloud config set compute/region europe-west1
-gcloud config set compute/zone europe-west1-b
-
-rm sa-credentials.json
-
-gcloud container clusters get-credentials zeebe-cluster
-
 if [ "${DRY_RUN:-false}" == "true" ]; then
   exit 0
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,8 @@ jobs:
         secretId: ${{ secrets.VAULT_SECRET_ID }}
         exportEnv: false # we rely on step outputs, no need for environment variables
         secrets: |
-          secret/data/products/zeebe/ci/jenkins ZEEBE_JENKINS_DEPLOY_SERVICEACCOUNT_JSON;
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
-          secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
           ${{ env.vault_secret_path }} clientSecret;
           ${{ env.vault_secret_path }} cloudClientSecret;
           ${{ env.vault_secret_path }} contactPoint;
@@ -105,15 +103,21 @@ jobs:
       env:
         MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
         MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
-
-    - name: Login to Docker Registry
+    - uses: google-github-actions/auth@v2
+      if: env.should_deploy_infra == 'true'
+      name: GCP Login
+      id: auth
+      with:
+        token_format: 'access_token'
+        workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/testbench-identity-pool/providers/testbench-identity-provider'
+        service_account: 'testbench-service-account@zeebe-io.iam.gserviceaccount.com'
+    - name: Login to GCR
       if: env.should_deploy_infra == 'true'
       uses: docker/login-action@v3
       with:
         registry: gcr.io
-        username: _json_key
-        password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
     - name: Build (and optionally Push) to Docker Registry
       uses: docker/build-push-action@v5
       with:
@@ -121,18 +125,17 @@ jobs:
         context: .
         tags: 'gcr.io/zeebe-io/zeebe-cluster-testbench:${{ env.docker_tag }}'
 
-    - name: Setup Cloud SDK
+    - uses: google-github-actions/get-gke-credentials@v2.0.0
       if: env.should_deploy_infra == 'true'
-      uses: google-github-actions/setup-gcloud@v2
       with:
-        install_components: gke-gcloud-auth-plugin
+        cluster_name: 'zeebe-cluster'
+        location: 'europe-west1-b'
 
     - name: Deploy Infrastructure
       if: env.should_deploy_infra == 'true'
       run: |
         .ci/scripts/deploy.sh "${{ env.docker_tag }}"
       env:
-        SA_CREDENTIALS: ${{ steps.secrets.outputs.ZEEBE_JENKINS_DEPLOY_SERVICEACCOUNT_JSON }}
         CLIENT_SECRET: ${{ steps.secrets.outputs.clientSecret }}
         CLOUD_CLIENT_SECRET: ${{ steps.secrets.outputs.cloudClientSecret }}
         CONTACT_POINT: ${{ steps.secrets.outputs.contactPoint }}


### PR DESCRIPTION
Recently I removed old services accounts from our IAM, see https://app.slack.com/client/T0PM0P1SA/C064CNSFKFF

This caused to fail the builts/deployments for testbench.

This PR migrates the old Jenkins service account JSON usage to the official workload identity federation usage, [which is recommended by Google](https://github.com/google-github-actions/auth?tab=readme-ov-file#workload-identity-federation-through-a-service-account).


I have set up a new service account and created a new workload identity pool, etc. Since I know had to do this multiple times already I wrote a script, which we can reuse the next time


```sh
#!/bin/bash
gcloud components update

# https://github.com/google-github-actions/auth?tab=readme-ov-file#workload-identity-federation-through-a-service-account

name="testbench"
detailedName="ZBTestbench"
org=zeebe-io
repo=zeebe-io/zeebe-cluster-testbench

export PROJECT_ID="zeebe-io"

gcloud iam service-accounts create "$name-service-account" \
  --project "${PROJECT_ID}"

gcloud iam workload-identity-pools create "$name-identity-pool" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --display-name="$detailedName identity pool"

export WORKLOAD_IDENTITY_POOL_ID=$(gcloud iam workload-identity-pools describe "$name-identity-pool" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --format="value(name)")

gcloud iam workload-identity-pools providers create-oidc "$name-identity-provider" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --workload-identity-pool="$name-identity-pool" \
  --display-name="$detailedName identity provider" \
  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.workflow=assertion.workflow,attribute.ref=assertion.ref" \
  --issuer-uri="https://token.actions.githubusercontent.com" \
  --attribute-condition="attribute.repository_owner=='$org'"

gcloud iam workload-identity-pools providers describe "$name-identity-provider" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --workload-identity-pool="$name-identity-pool" \
  --format="value(name)"

gcloud iam service-accounts add-iam-policy-binding "$name-service-account@${PROJECT_ID}.iam.gserviceaccount.com" \
  --project="${PROJECT_ID}" \
  --role="roles/iam.workloadIdentityUser" \
  --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_ID}/attribute.repository/${REPO}"

```

