### PR TITLE
ci: dont specify specific maven version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,6 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        maven-version: '3.6.2'
 
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven Settings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        maven-version: '3.6.2'
 
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven Settings


### PR DESCRIPTION
It's unclear to me why these jobs specify a specific maven version. It's not managed by any version manager, so it quickly gets out of date.

It was introduced with https://github.com/zeebe-io/zeebe-cluster-testbench/pull/802

Instead, it's fine to use the latest maven version for our CI. This is needed because the flatten maven plugin v1.6 requires a newer maven version then the one we currently specify in our CI.

This will help us merge:
- https://github.com/zeebe-io/zeebe-cluster-testbench/pull/977