### PR TITLE
refactor(core): remove guard clause for generation cloning

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -43,6 +43,9 @@
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
     </XML>
@@ -424,7 +427,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -43,9 +43,6 @@
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
-    <ScalaCodeStyleSettings>
-      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
-    </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
     </XML>
@@ -427,6 +424,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />

--- a/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandler.java
@@ -28,24 +28,6 @@ public class CreateGenerationInCamundaCloudHandler implements JobHandler {
     final var generationName = createGenerationName();
     final var templateGeneration = lookupTemplate(input.getGenerationTemplate());
 
-    if (templateGeneration.upgradeableFrom().isEmpty()) {
-      // This a shortcut until
-      // https://github.com/camunda-cloud/camunda-cloud-management-apps/issues/1731 is fixed
-      // Normally we would expect that we can clone all kind of generations but currently this is
-      // not possible.
-      // If we reference a generation without the upgradeableFrom reference (so no reference)
-      // we retrieve weird errors which are hard to debug.
-      // https://github.com/zeebe-io/zeebe-cluster-testbench/issues/945
-      client
-          .newThrowErrorCommand(job)
-          .errorCode(ERROR_CODE_ILLEGAL_GENERATION)
-          .errorMessage(
-              String.format(ERROR_MSG_EXPECTED_TO_CLONE_A_GENERATION, input.generationTemplate))
-          .send();
-
-      return;
-    }
-
     final var zeebeImage = input.getZeebeImage();
     final var operateImage = input.getOperateImage();
 

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/CreateGenerationInCamundaCloudHandlerTest.java
@@ -1,7 +1,6 @@
 package io.zeebe.clustertestbench.handler;
 
 import static io.zeebe.clustertestbench.internal.cloud.StubExternalConsoleAPIClient.DEFAULT_GENERATION_NAME;
-import static io.zeebe.clustertestbench.internal.cloud.StubExternalConsoleAPIClient.GENERATION_NAME_WITHOUT_UPGRADE_FROM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -93,22 +92,6 @@ class CreateGenerationInCamundaCloudHandlerTest {
 
       assertThat(request.operateVersion()).isNull();
       assertThat(request.zeebeVersion()).isNull();
-    }
-
-    @Test
-    public void shouldNotCreateGenerationWhenReferencingInvalidGeneration() throws Exception {
-      // given
-      activatedJobStub.setInputVariables(
-          Map.of(FIELD_GENERATION_TEMPLATE, GENERATION_NAME_WITHOUT_UPGRADE_FROM));
-
-      // when
-      sutCreateGenerationHandler.handle(jobClientStub, activatedJobStub);
-
-      // then
-      assertThat(activatedJobStub.hasThrownError()).isTrue();
-      assertThat(activatedJobStub.getErrorMessage())
-          .contains("Expected to clone a generation with upgradeableFrom reference")
-          .contains(GENERATION_NAME_WITHOUT_UPGRADE_FROM);
     }
 
     @Test


### PR DESCRIPTION
A bug in Camunda Cloud Console prevented cloning of generations that were not marked as upgradable from. The issue has been fixed and the guard clause needs to be removed from the testbench code.

closes #981