### PR TITLE
Improve failure messages

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
@@ -282,6 +282,25 @@ public class Launcher {
         Duration.ofSeconds(10));
   }
 
+  protected static String convertZeebeUrlToOperateUrl(final String endpoint) {
+    // Zeebe GRPC endpoint looks normally like this:
+    // <clusterId>.bru-2.zeebe.camunda.io/
+    //
+    // Operate looks like this:
+    // bru-2.operate.camunda.io/<clusterId>
+    //
+
+    // removing potential protocol from endpoint
+    var strippedEndpoint = endpoint.replace("http://", "");
+    strippedEndpoint = strippedEndpoint.replace("https://", "");
+
+    // finding index when clusterId stops
+    final int firstDotIndex = strippedEndpoint.indexOf('.');
+    final String baseEndpoint = strippedEndpoint.substring(firstDotIndex + 1);
+    final String operateBase = baseEndpoint.replace("zeebe", "operate");
+    return String.format("https://%s%s", operateBase, strippedEndpoint.substring(0, firstDotIndex));
+  }
+
   private void registerWorker(
       final ZeebeClient client,
       final String jobType,

--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
@@ -239,10 +239,15 @@ public class Launcher {
         client, "run-sequential-test-job", new SequentialTestHandler(), Duration.ofMinutes(30));
 
     final var slackNotificationService = new SlackNotificationService(slackWebhookUrl);
+
+    // Testbench cluster Operate url
+    final String operateUrl =
+        convertZeebeUrlToOperateUrl(testOrchestrationAuthenticatonDetails.getServerURL());
+
     registerWorker(
         client,
         "notify-engineers-job",
-        new NotifyEngineersHandler(slackNotificationService),
+        new NotifyEngineersHandler(slackNotificationService, operateUrl),
         Duration.ofSeconds(10));
     registerWorker(
         client,

--- a/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/bootstrap/Launcher.java
@@ -242,7 +242,7 @@ public class Launcher {
 
     // Testbench cluster Operate url
     final String operateUrl =
-        convertZeebeUrlToOperateUrl(testOrchestrationAuthenticatonDetails.getServerURL());
+        convertZeebeUrlToOperateUrl(testOrchestrationAuthenticatonDetails.getAudience());
 
     registerWorker(
         client,

--- a/core/src/test/java/io/zeebe/clustertestbench/bootstrap/ConvertUrlTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/bootstrap/ConvertUrlTest.java
@@ -1,0 +1,35 @@
+package io.zeebe.clustertestbench.bootstrap;
+
+import static io.zeebe.clustertestbench.bootstrap.Launcher.convertZeebeUrlToOperateUrl;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ConvertUrlTest {
+
+  @Test
+  public void shouldConvertToValidOperateURI() {
+    // given
+    final var endpoint = "https://wvdf8734-fr32-47a8-a3ed-5fi13265e523.bru-2.zeebe.camunda.io/";
+
+    // when
+    final String operateEndpoint = convertZeebeUrlToOperateUrl(endpoint);
+
+    // then
+    assertThat(operateEndpoint)
+        .isEqualTo("https://bru-2.operate.camunda.io/wvdf8734-fr32-47a8-a3ed-5fi13265e523");
+  }
+
+  @Test
+  public void shouldConvertToValidOperateURIAndHandleMissingProtocol() {
+    // given
+    final var endpoint = "wvdf8734-fr32-47a8-a3ed-5fi13265e523.bru-2.zeebe.camunda.io/";
+
+    // when
+    final String operateEndpoint = convertZeebeUrlToOperateUrl(endpoint);
+
+    // then
+    assertThat(operateEndpoint)
+        .isEqualTo("https://bru-2.operate.camunda.io/wvdf8734-fr32-47a8-a3ed-5fi13265e523");
+  }
+}

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandlerTest.java
@@ -47,7 +47,8 @@ public class NotifyEngineersHandlerTest {
   public void setUp() {
     simpleNotificationService = new SimpleNotificationService();
 
-    sutNotifyEngineersHandler = new NotifyEngineersHandler(simpleNotificationService);
+    sutNotifyEngineersHandler =
+        new NotifyEngineersHandler(simpleNotificationService, "http://url/clusterId");
 
     activatedJobStub = createActivatedJobStub();
   }
@@ -84,7 +85,8 @@ public class NotifyEngineersHandlerTest {
     final var mock = mock(CompleteJobCommandStep1.class);
     when(jobClientMock.newCompleteCommand(anyLong())).thenReturn(mock);
     final var jobMock = createActivatedJobStub();
-    final var notifyEngineersWorker = new NotifyEngineersHandler(notificationService);
+    final var notifyEngineersWorker =
+        new NotifyEngineersHandler(notificationService, "http://url/clusterid");
 
     // when
     assertThatThrownBy(() -> notifyEngineersWorker.handle(jobClientMock, jobMock))


### PR DESCRIPTION
Adds some better formatting, improved wording (speaking of target cluster) on the failure messages and adds the Operate URL to easily navigate to the orchestration cluster.

I will keep improving this, like adding logs URL, etc. but will do this later.



Example message:


```
:bpmn-error-throw-event:
_processID_ on _CLUSTER_PLAN_B_ failed for branch .
Check out here: http://url/clusterId

*Details:*

* Zeebe image: _ZEEBE:VERSION_
* Generation: _GENERATION_C_
* Target cluster : _CLUSTER_A_
* Target cluster Operate: https://localhost.test/
* Business key: http://jenkins/branch/build

*Failures:*

Failure count: 1

Error message 1
Error message 2
```