### PR TITLE
feat: add zbchaos console log url

### DIFF
--- a/core/src/main/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandler.java
+++ b/core/src/main/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandler.java
@@ -11,6 +11,8 @@ import io.zeebe.clustertestbench.testdriver.api.TestDriver.TestReportDTO;
 public class NotifyEngineersHandler implements JobHandler {
 
   private static final int TEST_FAILURE_SUMMARY_ITEMS = 10;
+  private static final String ZBCHAOS_LOG_URL =
+      "https://console.cloud.google.com/logs/query;query=labels.clusterId%3D%22-CLUSTER_ID-%22;duration=PT6H?project=zeebe-io";
 
   private static final String FAILURE_MESSAGE_FORMAT =
       """
@@ -20,11 +22,12 @@ Check out here: %s
 
 *Details:*
 
-* Zeebe image: _%s_
-* Generation: _%s_
-* Target cluster : _%s_ `%s`
-* Target cluster Operate: %s
-* Business key: %s
+ * Zeebe image: _%s_
+ * Generation: _%s_
+ * Target cluster : _%s_ `%s`
+ * Target cluster Operate: %s
+ * Business key: %s
+ * Zbchaos log: <%s|console log>
 
 *Failures:*
 
@@ -65,6 +68,7 @@ Failure count: %d
             input.getClusterId(),
             input.getOperateURL(),
             input.getBusinessKey(),
+            ZBCHAOS_LOG_URL.replace("-CLUSTER_ID-", input.clusterId),
             input.getTestReport().failureCount());
 
     resultBuilder.append(errorMessage);

--- a/core/src/test/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandlerTest.java
+++ b/core/src/test/java/io/zeebe/clustertestbench/handler/NotifyEngineersHandlerTest.java
@@ -33,6 +33,9 @@ public class NotifyEngineersHandlerTest {
   public static final String IMAGE = "ZEEBE:VERSION";
   public static final String BRANCH = "BRANCH";
   public static final String OPERATE_URL = "https://localhost.test";
+
+  public static final String ZBCHAOS_URL =
+      "https://console.cloud.google.com/logs/query;query=labels.clusterId%3D%22a1b2c3d4e-f5e6-d7c8-b9a8-b7c6d5e4f3e2%22;duration=PT6H?project=zeebe-io";
   public static final String PROCESS_ID = "processID";
   public static final String BUSINESS_KEY = "http://jenkins/branch/build";
   JobClientStub jobClientStub = new JobClientStub();
@@ -68,6 +71,7 @@ public class NotifyEngineersHandlerTest {
         .contains(BRANCH)
         .contains(OPERATE_URL)
         .contains(PROCESS_ID)
+        .contains(ZBCHAOS_URL)
         .contains("ERROR")
         .contains(BUSINESS_KEY);
 


### PR DESCRIPTION
When failing chaos experiments we have a long way to find the right logs, especially if we want to look at the zbchaos logs, as this is not linked.

With this PR we close the gap and have a direct connection to the running pods logs