### PR TITLE
Reduce indirection for QA trigger

### DIFF
--- a/processes/qa-github-trigger.bpmn
+++ b/processes/qa-github-trigger.bpmn
@@ -1,22 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0b1jbb5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="3cd8340" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0" camunda:diagramRelationId="99d27a66-6456-4fa0-982c-6d83dd8bfaa5">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0b1jbb5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.17.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0" camunda:diagramRelationId="99d27a66-6456-4fa0-982c-6d83dd8bfaa5">
   <bpmn:process id="qa-github-trigger" name="QA Github Trigger" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_15uwe9t</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_15uwe9t" sourceRef="StartEvent_1" targetRef="Activity_0gxslr9" />
-    <bpmn:sequenceFlow id="Flow_148ojn3" sourceRef="Activity_0gxslr9" targetRef="Gateway_02ekcf8" />
+    <bpmn:sequenceFlow id="Flow_15uwe9t" sourceRef="StartEvent_1" targetRef="Activity_19achfg" />
     <bpmn:endEvent id="Event_1m39n9l">
       <bpmn:incoming>Flow_16e5cin</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_16e5cin" sourceRef="fetch-result-job" targetRef="Event_1m39n9l" />
-    <bpmn:callActivity id="Activity_0gxslr9" name="Call QA Test process">
-      <bpmn:extensionElements>
-        <zeebe:calledElement processId="=processId" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_15uwe9t</bpmn:incoming>
-      <bpmn:outgoing>Flow_148ojn3</bpmn:outgoing>
-    </bpmn:callActivity>
     <bpmn:serviceTask id="fetch-result-job" name="Notify Failure" zeebe:modelerTemplate="io.camunda.connectors.Slack.v1" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20%20viewBox%3D%220%200%20127%20127%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20d%3D%22M27.2%2080c0%207.3-5.9%2013.2-13.2%2013.2C6.7%2093.2.8%2087.3.8%2080c0-7.3%205.9-13.2%2013.2-13.2h13.2V80zm6.6%200c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2v33c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V80z%22%20fill%3D%22%23E01E5A%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M47%2027c-7.3%200-13.2-5.9-13.2-13.2C33.8%206.5%2039.7.6%2047%20.6c7.3%200%2013.2%205.9%2013.2%2013.2V27H47zm0%206.7c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H13.9C6.6%2060.1.7%2054.2.7%2046.9c0-7.3%205.9-13.2%2013.2-13.2H47z%22%20fill%3D%22%2336C5F0%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M99.9%2046.9c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H99.9V46.9zm-6.6%200c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V13.8C66.9%206.5%2072.8.6%2080.1.6c7.3%200%2013.2%205.9%2013.2%2013.2v33.1z%22%20fill%3D%22%232EB67D%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M80.1%2099.8c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3%200-13.2-5.9-13.2-13.2%200-7.3%205.9-13.2%2013.2-13.2h33.1c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H80.1z%22%20fill%3D%22%23ECB22E%22%2F%3E%0A%3C%2Fsvg%3E%0A">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="io.camunda:slack:1" />
@@ -32,7 +24,7 @@
       <bpmn:outgoing>Flow_16e5cin</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_02ekcf8" default="Flow_093ioqi">
-      <bpmn:incoming>Flow_148ojn3</bpmn:incoming>
+      <bpmn:incoming>Flow_06nk95c</bpmn:incoming>
       <bpmn:outgoing>Flow_1v4lwsp</bpmn:outgoing>
       <bpmn:outgoing>Flow_093ioqi</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -58,7 +50,7 @@
       <bpmn:incoming>Flow_1vyp0cy</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1vyp0cy" sourceRef="Activity_0d6h12d" targetRef="Event_0kcubc0" />
-    <bpmn:boundaryEvent id="Event_1p9ayal" cancelActivity="false" attachedToRef="Activity_0gxslr9">
+    <bpmn:boundaryEvent id="Event_1p9ayal" cancelActivity="false" attachedToRef="Activity_19achfg">
       <bpmn:outgoing>Flow_032f7m5</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0bb19ml">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT6H</bpmn:timeDuration>
@@ -83,6 +75,230 @@
       <bpmn:incoming>Flow_032f7m5</bpmn:incoming>
       <bpmn:outgoing>Flow_1o4exgt</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:subProcess id="Activity_19achfg" name="QA Protocol">
+      <bpmn:incoming>Flow_15uwe9t</bpmn:incoming>
+      <bpmn:outgoing>Flow_06nk95c</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0sc5dtl">
+        <bpmn:outgoing>Flow_1qxina4</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_1q5ta1t">
+        <bpmn:incoming>Flow_0uh6yp1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="Activity_1grheqa" name="Create Generation In Camunda Cloud">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="create-generation-in-camunda-cloud-job" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1qxina4</bpmn:incoming>
+        <bpmn:outgoing>Flow_1qpk3b2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="Activity_0lx0qei" name="Trigger Clean Up Generaton Process">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="trigger-message-start-event-job" />
+          <zeebe:taskHeaders>
+            <zeebe:header key="messageName" value="Clean Up Generation" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_18lr5bn</bpmn:incoming>
+        <bpmn:outgoing>Flow_0uh6yp1</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_1qxina4" sourceRef="Event_0sc5dtl" targetRef="Activity_1grheqa" />
+      <bpmn:sequenceFlow id="Flow_0uh6yp1" sourceRef="Activity_0lx0qei" targetRef="Event_1q5ta1t" />
+      <bpmn:subProcess id="Activity_10fu1ay" name="Run All Tests in Camunda Cloud per Cluster Plan">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="=&#34;Chaos, Belgium, Europe (europe-west1)&#34;" target="region" />
+            <zeebe:input source="=[&#34;Production - S&#34;]" target="clusterPlans" />
+            <zeebe:input source="={&#34;steps&#34;:3,&#34;iterations&#34;:10,&#34;maxTimeForIteration&#34;:&#34;PT20S&#34;,&#34;maxTimeForCompleteTest&#34;:&#34;PT4M&#34;}" target="sequentialTestParams" />
+            <zeebe:input source="={}" target="chaosTestParams" />
+            <zeebe:input source="=&#34;QA Protocol&#34;" target="rootProcess" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1qpk3b2</bpmn:incoming>
+        <bpmn:outgoing>Flow_18lr5bn</bpmn:outgoing>
+        <bpmn:startEvent id="Event_0hylhut" name="Start">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:output source="=&#34;SKIPPED&#34;" target="chaosExperimentResult" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+          <bpmn:outgoing>Flow_1ux2dvf</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:callActivity id="Activity_1audm0k" name="Run sequential tests in Camunda Cloud">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="=sequential-test" propagateAllChildVariables="false" />
+            <zeebe:ioMapping>
+              <zeebe:input source="=sequentialTestParams" target="testParams" />
+              <zeebe:input source="=&#34;sequential-test&#34;" target="testProcessId" />
+              <zeebe:output source="=testReport.testResult" target="sequentialTestResult" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_06gymln</bpmn:incoming>
+          <bpmn:outgoing>Flow_0bt5j3f</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:endEvent id="Event_18t3lrm" name="End">
+          <bpmn:incoming>Flow_00mbwq7</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:serviceTask id="Activity_1plx17g" name="Map names to UUIDs">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="map-names-to-uuids-job" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1ux2dvf</bpmn:incoming>
+          <bpmn:outgoing>Flow_0hapjd9</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:callActivity id="Activity_0im7jbn" name="Run chaos experiments in Camunda Cloud">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="=chaosToolkit" propagateAllChildVariables="false" />
+            <zeebe:ioMapping>
+              <zeebe:input source="=chaosTestParams" target="testParams" />
+              <zeebe:input source="=&#34;chaosToolkit&#34;" target="testProcessId" />
+              <zeebe:output source="=testReport.testResult" target="chaosExperimentResult" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_09bh7y2</bpmn:incoming>
+          <bpmn:outgoing>Flow_09ppuyl</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:exclusiveGateway id="Gateway_1fg9na6" name="Chaos region?" default="Flow_0hn5u24">
+          <bpmn:incoming>Flow_10alfie</bpmn:incoming>
+          <bpmn:outgoing>Flow_09bh7y2</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0hn5u24</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:serviceTask id="Activity_1rvj5o3" name="Aggregate Test Results">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="aggregate-test-results-job" retries="3" />
+            <zeebe:taskHeaders>
+              <zeebe:header key="variableNames" value="sequentialTestResult, chaosExperimentResult" />
+            </zeebe:taskHeaders>
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_09w9u5y</bpmn:incoming>
+          <bpmn:incoming>Flow_09wpna0</bpmn:incoming>
+          <bpmn:outgoing>Flow_00mbwq7</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="Flow_1ux2dvf" sourceRef="Event_0hylhut" targetRef="Activity_1plx17g" />
+        <bpmn:sequenceFlow id="Flow_00mbwq7" sourceRef="Activity_1rvj5o3" targetRef="Event_18t3lrm" />
+        <bpmn:sequenceFlow id="Flow_0hapjd9" sourceRef="Activity_1plx17g" targetRef="Activity_02j7vxu" />
+        <bpmn:sequenceFlow id="Flow_09bh7y2" name="Yes" sourceRef="Gateway_1fg9na6" targetRef="Activity_0im7jbn">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=region = "Chaos, Belgium, Europe (europe-west1)"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_09ppuyl" sourceRef="Activity_0im7jbn" targetRef="Gateway_1we7jo9" />
+        <bpmn:sequenceFlow id="Flow_0hn5u24" name="No" sourceRef="Gateway_1fg9na6" targetRef="Gateway_00dnbxt" />
+        <bpmn:callActivity id="Activity_02j7vxu" name="Prepare Zeebe Cluster in Camunda Cloud">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="prepare-zeebe-cluster-in-camunda-cloud" propagateAllChildVariables="false" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0hapjd9</bpmn:incoming>
+          <bpmn:outgoing>Flow_06gymln</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:boundaryEvent id="Event_181hrs2" attachedToRef="Activity_02j7vxu">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:output source="=&#34;FAILED&#34;" target="testReport.testResult" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+          <bpmn:outgoing>Flow_09w9u5y</bpmn:outgoing>
+          <bpmn:errorEventDefinition id="ErrorEventDefinition_0h462pt" errorRef="Error_18gl439" />
+        </bpmn:boundaryEvent>
+        <bpmn:sequenceFlow id="Flow_09w9u5y" sourceRef="Event_181hrs2" targetRef="Activity_1rvj5o3" />
+        <bpmn:sequenceFlow id="Flow_06gymln" sourceRef="Activity_02j7vxu" targetRef="Activity_1audm0k" />
+        <bpmn:exclusiveGateway id="Gateway_1we7jo9" name="test result?">
+          <bpmn:incoming>Flow_09ppuyl</bpmn:incoming>
+          <bpmn:outgoing>Flow_0juhhfh</bpmn:outgoing>
+          <bpmn:outgoing>Flow_102b8uu</bpmn:outgoing>
+          <bpmn:outgoing>Flow_1lk7i9o</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:exclusiveGateway id="Gateway_1ch9nux">
+          <bpmn:incoming>Flow_102b8uu</bpmn:incoming>
+          <bpmn:incoming>Flow_1lk7i9o</bpmn:incoming>
+          <bpmn:outgoing>Flow_0zl65v4</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:serviceTask id="Activity_0yf40yp" name="Destroy Zeebe Cluster in Camunda Cloud">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="destroy-zeebe-cluster-in-camunda-cloud-job" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0zl65v4</bpmn:incoming>
+          <bpmn:outgoing>Flow_1w6t966</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="Flow_0juhhfh" name="FAILED" sourceRef="Gateway_1we7jo9" targetRef="Gateway_0ofzvd1">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "FAILED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_102b8uu" name="PASSED" sourceRef="Gateway_1we7jo9" targetRef="Gateway_1ch9nux">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "PASSED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_1lk7i9o" name="SKIPPED" sourceRef="Gateway_1we7jo9" targetRef="Gateway_1ch9nux">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "SKIPPED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_0zl65v4" sourceRef="Gateway_1ch9nux" targetRef="Activity_0yf40yp" />
+        <bpmn:exclusiveGateway id="Gateway_0gveope" name="test result?">
+          <bpmn:incoming>Flow_0bt5j3f</bpmn:incoming>
+          <bpmn:outgoing>Flow_0kfg511</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0mtfisc</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0ovyxag</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:serviceTask id="Activity_1g2y7cs" name="Trigger Analyse Cluster Process">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="trigger-message-start-event-job" />
+            <zeebe:taskHeaders>
+              <zeebe:header key="messageName" value="Analyse Cluster" />
+            </zeebe:taskHeaders>
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0y3o186</bpmn:incoming>
+          <bpmn:outgoing>Flow_1yaf71p</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:exclusiveGateway id="Gateway_114ailq">
+          <bpmn:incoming>Flow_0mtfisc</bpmn:incoming>
+          <bpmn:incoming>Flow_0ovyxag</bpmn:incoming>
+          <bpmn:outgoing>Flow_10alfie</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_0kfg511" name="FAILED" sourceRef="Gateway_0gveope" targetRef="Gateway_0ofzvd1">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "FAILED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_0mtfisc" name="PASSED" sourceRef="Gateway_0gveope" targetRef="Gateway_114ailq">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "PASSED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_0ovyxag" name="SKIPPED" sourceRef="Gateway_0gveope" targetRef="Gateway_114ailq">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=testReport.testResult = "SKIPPED"</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_0bt5j3f" sourceRef="Activity_1audm0k" targetRef="Gateway_0gveope" />
+        <bpmn:sequenceFlow id="Flow_10alfie" sourceRef="Gateway_114ailq" targetRef="Gateway_1fg9na6" />
+        <bpmn:exclusiveGateway id="Gateway_0ofzvd1">
+          <bpmn:incoming>Flow_0kfg511</bpmn:incoming>
+          <bpmn:incoming>Flow_0juhhfh</bpmn:incoming>
+          <bpmn:outgoing>Flow_0y3o186</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_0y3o186" sourceRef="Gateway_0ofzvd1" targetRef="Activity_1g2y7cs" />
+        <bpmn:exclusiveGateway id="Gateway_00dnbxt">
+          <bpmn:incoming>Flow_1w6t966</bpmn:incoming>
+          <bpmn:incoming>Flow_1yaf71p</bpmn:incoming>
+          <bpmn:incoming>Flow_0hn5u24</bpmn:incoming>
+          <bpmn:outgoing>Flow_09wpna0</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_1w6t966" sourceRef="Activity_0yf40yp" targetRef="Gateway_00dnbxt" />
+        <bpmn:sequenceFlow id="Flow_1yaf71p" sourceRef="Activity_1g2y7cs" targetRef="Gateway_00dnbxt" />
+        <bpmn:sequenceFlow id="Flow_09wpna0" sourceRef="Gateway_00dnbxt" targetRef="Activity_1rvj5o3" />
+        <bpmn:textAnnotation id="TextAnnotation_0wdc7kl">
+          <bpmn:text>By design we run chaos experiments only in a dedicated region ("Chaos, Belgium, Europe (europe-west1)")</bpmn:text>
+        </bpmn:textAnnotation>
+        <bpmn:association id="Association_1q6rj6r" sourceRef="Activity_0im7jbn" targetRef="TextAnnotation_0wdc7kl" />
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_18lr5bn" sourceRef="Activity_10fu1ay" targetRef="Activity_0lx0qei" />
+      <bpmn:sequenceFlow id="Flow_1qpk3b2" sourceRef="Activity_1grheqa" targetRef="Activity_10fu1ay" />
+      <bpmn:textAnnotation id="TextAnnotation_02vo6ud">
+        <bpmn:text>Defaults:
+region = "Chaos, Belgium, Europe (europe-west1)"
+clusterPlans = ["Development", "Production - S", "Production - M", "Production - L"]
+sequentialTestParams = {"steps":3,"iterations":10,"maxTimeForIteration":"PT20S","maxTimeForCompleteTest":"PT4M"}</bpmn:text>
+      </bpmn:textAnnotation>
+      <bpmn:textAnnotation id="TextAnnotation_1kzklxc">
+        <bpmn:text>zeebeImage: Zeebe image to use
+generationTemplate: existing genration used as template for the versions of Operate and ElasticSearch
+channel: channel in which the QA tests shall be run</bpmn:text>
+      </bpmn:textAnnotation>
+      <bpmn:textAnnotation id="TextAnnotation_01nrz8c">
+        <bpmn:text>Trigger for asynchronous process. This way this process can terminate immediately, and the generation will be cleaned up as soon as it is no longer used</bpmn:text>
+      </bpmn:textAnnotation>
+      <bpmn:association id="Association_0kxaq8p" sourceRef="Event_0sc5dtl" targetRef="TextAnnotation_1kzklxc" />
+      <bpmn:association id="Association_1y7yx73" sourceRef="Activity_0lx0qei" targetRef="TextAnnotation_01nrz8c" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_06nk95c" sourceRef="Activity_19achfg" targetRef="Gateway_02ekcf8" />
     <bpmn:textAnnotation id="TextAnnotation_0sdpa5l">
       <bpmn:text>Input:
 processId - process to call
@@ -91,86 +307,330 @@ branch - used in slack notification</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1mm0jby" sourceRef="StartEvent_1" targetRef="TextAnnotation_0sdpa5l" />
   </bpmn:process>
+  <bpmn:error id="Error_18gl439" name="Prepare Zeebe Cluster Failed" errorCode="prepare-zeebe-cluster-failed" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="qa-github-trigger">
       <bpmndi:BPMNShape id="TextAnnotation_0sdpa5l_di" bpmnElement="TextAnnotation_0sdpa5l">
-        <dc:Bounds x="147" y="80" width="323" height="70" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="169" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1m39n9l_di" bpmnElement="Event_1m39n9l">
-        <dc:Bounds x="822" y="169" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0henker_di" bpmnElement="Activity_0gxslr9">
-        <dc:Bounds x="270" y="147" width="100" height="80" />
+        <dc:Bounds x="160" y="410" width="323" height="70" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_192mgzz_di" bpmnElement="fetch-result-job">
-        <dc:Bounds x="610" y="147" width="100" height="80" />
+        <dc:Bounds x="3590" y="387" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x0dwck_di" bpmnElement="Activity_0pskk8p">
+        <dc:Bounds x="3590" y="600" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fxl2du_di" bpmnElement="Activity_0d6h12d">
+        <dc:Bounds x="3590" y="500" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_02ekcf8_di" bpmnElement="Gateway_02ekcf8" isMarkerVisible="true">
-        <dc:Bounds x="445" y="162" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0fxl2du_di" bpmnElement="Activity_0d6h12d">
-        <dc:Bounds x="610" y="260" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="3245" y="515" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0kcubc0_di" bpmnElement="Event_0kcubc0">
-        <dc:Bounds x="822" y="282" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x0dwck_di" bpmnElement="Activity_0pskk8p">
-        <dc:Bounds x="610" y="370" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="3742" y="522" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gg61w8_di" bpmnElement="Event_0gg61w8">
-        <dc:Bounds x="822" y="392" width="36" height="36" />
+        <dc:Bounds x="3742" y="622" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1mm0jby_di" bpmnElement="Association_1mm0jby">
-        <di:waypoint x="197" y="169" />
-        <di:waypoint x="197" y="150" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_0many0d_di" bpmnElement="Event_1p9ayal">
-        <dc:Bounds x="332" y="209" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1m39n9l_di" bpmnElement="Event_1m39n9l">
+        <dc:Bounds x="3742" y="409" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_15uwe9t_di" bpmnElement="Flow_15uwe9t">
-        <di:waypoint x="215" y="187" />
-        <di:waypoint x="270" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16e5cin_di" bpmnElement="Flow_16e5cin">
-        <di:waypoint x="710" y="187" />
-        <di:waypoint x="822" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_148ojn3_di" bpmnElement="Flow_148ojn3">
-        <di:waypoint x="370" y="187" />
-        <di:waypoint x="445" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v4lwsp_di" bpmnElement="Flow_1v4lwsp">
-        <di:waypoint x="495" y="187" />
-        <di:waypoint x="610" y="187" />
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="262" y="502" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19achfg_di" bpmnElement="Activity_19achfg" isExpanded="true">
+        <dc:Bounds x="440" y="80" width="2640" height="760" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0vtao6x" bpmnElement="TextAnnotation_01nrz8c">
+        <dc:Bounds x="2740" y="610" width="310" height="53" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8yyap" bpmnElement="TextAnnotation_1kzklxc">
+        <dc:Bounds x="510" y="200" width="608" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_05skzh4" bpmnElement="TextAnnotation_02vo6ud">
+        <dc:Bounds x="960" y="110" width="750" height="70" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03mfm7z" bpmnElement="Activity_0lx0qei">
+        <dc:Bounds x="2780" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0841hki" bpmnElement="Event_1q5ta1t">
+        <dc:Bounds x="2932" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ne5pyl" bpmnElement="Activity_1grheqa">
+        <dc:Bounds x="600" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1e1r845" bpmnElement="Event_0sc5dtl">
+        <dc:Bounds x="496" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10fu1ay_di" bpmnElement="Activity_10fu1ay" isExpanded="true">
+        <dc:Bounds x="820" y="270" width="1880" height="490" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1u9adz9" bpmnElement="TextAnnotation_0wdc7kl">
+        <dc:Bounds x="1700" y="370" width="208" height="70" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1y43tf2" bpmnElement="Gateway_1fg9na6" isMarkerVisible="true">
+        <dc:Bounds x="1635" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="538" y="169" width="30" height="14" />
+          <dc:Bounds x="1624" y="535" width="72" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_06tuanr" bpmnElement="Event_0hylhut">
+        <dc:Bounds x="862" y="482" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="871" y="525" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b2qo9h" bpmnElement="Activity_1plx17g">
+        <dc:Bounds x="940" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1qyuiv9" bpmnElement="Activity_02j7vxu">
+        <dc:Bounds x="1070" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_06t91as" bpmnElement="Activity_1audm0k">
+        <dc:Bounds x="1210" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_023sujx" bpmnElement="Gateway_0gveope" isMarkerVisible="true">
+        <dc:Bounds x="1395" y="475" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1343" y="463" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_012efjm" bpmnElement="Gateway_114ailq" isMarkerVisible="true">
+        <dc:Bounds x="1515" y="475" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ojhbo8" bpmnElement="Gateway_1we7jo9" isMarkerVisible="true">
+        <dc:Bounds x="1975" y="475" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1923" y="463" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1r4ne8c" bpmnElement="Gateway_1ch9nux" isMarkerVisible="true">
+        <dc:Bounds x="2135" y="475" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0u3epdc" bpmnElement="Activity_0yf40yp">
+        <dc:Bounds x="2240" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ofzvd1_di" bpmnElement="Gateway_0ofzvd1" isMarkerVisible="true">
+        <dc:Bounds x="1975" y="625" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15nkbk8" bpmnElement="Activity_1g2y7cs">
+        <dc:Bounds x="2240" y="610" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_00dnbxt_di" bpmnElement="Gateway_00dnbxt" isMarkerVisible="true">
+        <dc:Bounds x="2395" y="475" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0jimocu" bpmnElement="Activity_1rvj5o3">
+        <dc:Bounds x="2490" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01zuyfy" bpmnElement="Event_18t3lrm">
+        <dc:Bounds x="2642" y="482" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2650" y="525" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1eu1zce" bpmnElement="Activity_0im7jbn">
+        <dc:Bounds x="1780" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_026g0co" bpmnElement="Association_1q6rj6r">
+        <di:waypoint x="1842" y="460" />
+        <di:waypoint x="1853" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1wxqc5j" bpmnElement="Event_181hrs2">
+        <dc:Bounds x="1132" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10alfie_di" bpmnElement="Flow_10alfie">
+        <di:waypoint x="1565" y="500" />
+        <di:waypoint x="1635" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1jwhesl" bpmnElement="Flow_09bh7y2">
+        <di:waypoint x="1685" y="500" />
+        <di:waypoint x="1780" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1723" y="482" width="19" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1o81ip0" bpmnElement="Flow_0hn5u24">
+        <di:waypoint x="1660" y="475" />
+        <di:waypoint x="1660" y="340" />
+        <di:waypoint x="2420" y="340" />
+        <di:waypoint x="2420" y="475" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2052" y="313" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_06wmy4t" bpmnElement="Flow_1ux2dvf">
+        <di:waypoint x="898" y="500" />
+        <di:waypoint x="940" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0hrxnnj" bpmnElement="Flow_0hapjd9">
+        <di:waypoint x="1040" y="500" />
+        <di:waypoint x="1070" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06gymln_di" bpmnElement="Flow_06gymln">
+        <di:waypoint x="1170" y="500" />
+        <di:waypoint x="1210" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bt5j3f_di" bpmnElement="Flow_0bt5j3f">
+        <di:waypoint x="1310" y="500" />
+        <di:waypoint x="1395" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0vdbvgc" bpmnElement="Flow_0kfg511">
+        <di:waypoint x="1420" y="525" />
+        <di:waypoint x="1420" y="650" />
+        <di:waypoint x="1975" y="650" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1741" y="673" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0mw5llk" bpmnElement="Flow_0mtfisc">
+        <di:waypoint x="1445" y="500" />
+        <di:waypoint x="1515" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1445" y="503" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0e5x05x" bpmnElement="Flow_0ovyxag">
+        <di:waypoint x="1420" y="475" />
+        <di:waypoint x="1420" y="410" />
+        <di:waypoint x="1540" y="410" />
+        <di:waypoint x="1540" y="475" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1431" y="413" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0lz8g2t" bpmnElement="Flow_09ppuyl">
+        <di:waypoint x="1880" y="500" />
+        <di:waypoint x="1975" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1rcxemx" bpmnElement="Flow_0juhhfh">
+        <di:waypoint x="2000" y="525" />
+        <di:waypoint x="2000" y="625" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1951" y="613" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0jz9i76" bpmnElement="Flow_102b8uu">
+        <di:waypoint x="2025" y="500" />
+        <di:waypoint x="2135" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2038" y="503" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1q0aosc" bpmnElement="Flow_1lk7i9o">
+        <di:waypoint x="2000" y="475" />
+        <di:waypoint x="2000" y="410" />
+        <di:waypoint x="2160" y="410" />
+        <di:waypoint x="2160" y="475" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2023" y="413" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0sik4uy" bpmnElement="Flow_0zl65v4">
+        <di:waypoint x="2185" y="500" />
+        <di:waypoint x="2240" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1w6t966_di" bpmnElement="Flow_1w6t966">
+        <di:waypoint x="2340" y="500" />
+        <di:waypoint x="2395" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y3o186_di" bpmnElement="Flow_0y3o186">
+        <di:waypoint x="2025" y="650" />
+        <di:waypoint x="2240" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yaf71p_di" bpmnElement="Flow_1yaf71p">
+        <di:waypoint x="2340" y="650" />
+        <di:waypoint x="2420" y="650" />
+        <di:waypoint x="2420" y="525" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09wpna0_di" bpmnElement="Flow_09wpna0">
+        <di:waypoint x="2445" y="500" />
+        <di:waypoint x="2490" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09w9u5y_di" bpmnElement="Flow_09w9u5y">
+        <di:waypoint x="1150" y="558" />
+        <di:waypoint x="1150" y="720" />
+        <di:waypoint x="2540" y="720" />
+        <di:waypoint x="2540" y="540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1284nzm" bpmnElement="Flow_00mbwq7">
+        <di:waypoint x="2590" y="500" />
+        <di:waypoint x="2642" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0gpm4vx" bpmnElement="Association_1y7yx73">
+        <di:waypoint x="2830" y="550" />
+        <di:waypoint x="2802" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_03zj7ll" bpmnElement="Association_0kxaq8p">
+        <di:waypoint x="517" y="492" />
+        <di:waypoint x="556" y="248" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1s7k484" bpmnElement="Flow_1qxina4">
+        <di:waypoint x="532" y="510" />
+        <di:waypoint x="600" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qpk3b2_di" bpmnElement="Flow_1qpk3b2">
+        <di:waypoint x="700" y="510" />
+        <di:waypoint x="820" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18lr5bn_di" bpmnElement="Flow_18lr5bn">
+        <di:waypoint x="2700" y="510" />
+        <di:waypoint x="2780" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_06vbmug" bpmnElement="Flow_0uh6yp1">
+        <di:waypoint x="2880" y="510" />
+        <di:waypoint x="2932" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1mm0jby_di" bpmnElement="Association_1mm0jby">
+        <di:waypoint x="267" y="507" />
+        <di:waypoint x="242" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0many0d_di" bpmnElement="Event_1p9ayal">
+        <dc:Bounds x="792" y="822" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16e5cin_di" bpmnElement="Flow_16e5cin">
+        <di:waypoint x="3690" y="427" />
+        <di:waypoint x="3742" y="427" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v4lwsp_di" bpmnElement="Flow_1v4lwsp">
+        <di:waypoint x="3270" y="515" />
+        <di:waypoint x="3270" y="427" />
+        <di:waypoint x="3590" y="427" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3244" y="462" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06nk95c_di" bpmnElement="Flow_06nk95c">
+        <di:waypoint x="3080" y="540" />
+        <di:waypoint x="3245" y="540" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_093ioqi_di" bpmnElement="Flow_093ioqi">
-        <di:waypoint x="470" y="212" />
-        <di:waypoint x="470" y="300" />
-        <di:waypoint x="610" y="300" />
+        <di:waypoint x="3295" y="540" />
+        <di:waypoint x="3590" y="540" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1vyp0cy_di" bpmnElement="Flow_1vyp0cy">
-        <di:waypoint x="710" y="300" />
-        <di:waypoint x="822" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_032f7m5_di" bpmnElement="Flow_032f7m5">
-        <di:waypoint x="350" y="245" />
-        <di:waypoint x="350" y="410" />
-        <di:waypoint x="610" y="410" />
+        <di:waypoint x="3690" y="540" />
+        <di:waypoint x="3742" y="540" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1o4exgt_di" bpmnElement="Flow_1o4exgt">
-        <di:waypoint x="710" y="410" />
-        <di:waypoint x="822" y="410" />
+        <di:waypoint x="3690" y="640" />
+        <di:waypoint x="3742" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_032f7m5_di" bpmnElement="Flow_032f7m5">
+        <di:waypoint x="810" y="858" />
+        <di:waypoint x="810" y="920" />
+        <di:waypoint x="3640" y="920" />
+        <di:waypoint x="3640" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15uwe9t_di" bpmnElement="Flow_15uwe9t">
+        <di:waypoint x="298" y="520" />
+        <di:waypoint x="440" y="520" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
This PR reduces the complexity of our process models (by factor 5) and need of tests clusters by 50%.

We have one abstraction/call-activity layer:

![qa-github-trigger](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/13b30197-a965-4eeb-885c-f9cb617f74c0)

**Before:**

The QA trigger process model was quite abstract, and going to find the right chaos orchestration was several layers hidden behind call activities.

We needed 5+ process models to reach the actual orchestraction of chaos experiments.

QA-Github-trigger
![step1](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/6453a590-b1cc-413a-b489-c744dfee0af3)
QA-protocol
![step2](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/53bd2aa8-0799-4c2a-88fa-605ee4330f84)
run-all-tests-in-camunda-cloud-per-cluster-plan
![step3](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/70b73523-56a5-47fc-a5d1-f84d54267059)
run-all-tests-in-camunda-cloud
![step4](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/d9dc753d-48fc-41df-a217-50a1bb42c2da)
run-test-in-camunda-cloud
![step5](https://github.com/zeebe-io/zeebe-cluster-testbench/assets/2758593/29c3200e-d5e5-40a4-906a-64ed3f686a53)



**Details:**

This PR should reduce the indirection and clean up some unnecessary abstractions.

- Removed/inlined several call activities that had no real use.
- For example, the process run all tests (the name itself was confusing as it shared the prefix with another one), and we never ran against several cluster plans. (only at the begin).
- The change should make it easier to understand what is going on and where to find the correct execution.
- with the refactoring we now instead of creating two clusters, per run we now have one.
  - First sequential tests are executed (which are not much) and afterward the chaos experiments, that should be fine and reduces cost by 50 %. Especially it reduced another abstraction.


