### PR TITLE
chore: remove bors.toml config file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,9 +160,8 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.slackWebhookUrl }}
 
   test-summary:
-    # Used by bors to check all tests, including the unit test matrix.
+    # Check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
-    # This name is hard-referenced from bors.toml; remember to update that if this name changes
     name: Test summary
     runs-on: ubuntu-latest
     needs:

--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-  "Test summary"
-]
-
-required_approvals = 0
-
-delete_merged_branches = true
-
-cut_body_after = "# Pull Request Checklist"


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/633 and the removal of Bors instances.

This PR removes the `bors.toml` file, which is no longer used.
